### PR TITLE
When filtering demos on date, use end of date (23:59:59) of DateStatsTo

### DIFF
--- a/src/Services/CacheService.cs
+++ b/src/Services/CacheService.cs
@@ -119,7 +119,7 @@ namespace CSGO_Demos_Manager.Services
 									if (filterOnSelectedDate)
 									{
 										if(demo.Date >= Properties.Settings.Default.DateStatsFrom
-											&& demo.Date <= Properties.Settings.Default.DateStatsTo) demos.Add(demo);
+											&& demo.Date <= EndOfDay(Properties.Settings.Default.DateStatsTo)) demos.Add(demo);
 									}
 									else
 									{
@@ -151,6 +151,15 @@ namespace CSGO_Demos_Manager.Services
 
 			return demos;
 		}
+
+        /// <summary>
+        /// Returns 23:59:59 of the given date
+        /// </summary>
+        /// <param name="date"></param>
+        /// <returns></returns>
+        private static DateTime EndOfDay(DateTime date) {
+            return date.Date.AddDays(1).AddSeconds(-1);
+        }
 
 		/// <summary>
 		/// Check if the JSON file for the demo exist


### PR DESCRIPTION
I noticed that the Stats page didn't include new demos I imported of the current date. This was due to DateStatsTo being at midnight (at the beginning of today) instead of at then end of the day. Therefore, demos inside that day were excluded. 

Since today is used as a default for DateStatsTo (if I'm not mistaken), this seems undesirable, or should at least be configurable.

This is a simple fix for the problem, but I haven't been able to test it since I don't have the Telerik binaries. Furthermore, you might want to place the helper function in an extensions class or something like that, as it doesn't really fit in CacheService.

