### PR TITLE
Fixes #261

### DIFF
--- a/Services/Concrete/Analyzer/EseaAnalyzer.cs
+++ b/Services/Concrete/Analyzer/EseaAnalyzer.cs
@@ -133,6 +133,8 @@ namespace Services.Concrete.Analyzer
 		{
 			if (!IsMatchStarted) return;
 
+            if (IsSwapTeamRequired && CurrentRound.Number == 1) IsSwapTeamRequired = false;
+
 			// Detect teams name only during first half
 			if (CurrentRound.Number < 15)
 			{


### PR DESCRIPTION
If a teamswap is required after a knife round, the team names have not yet been set. In "HandleRoundStart" the names will be set to the already correct teams, but as "IsSwapTeamRequired" is true, a teamswap will take place right after, resulting in a double swap.