### PR TITLE
Fixed incorrect player kills

### DIFF
--- a/Core/Models/Player.cs
+++ b/Core/Models/Player.cs
@@ -1071,7 +1071,7 @@ namespace Core.Models
 		private void OnKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			TeamKillCount = Kills.Count(k => k.KilledSide == k.KillerSide);
-			KillCount = Kills.Count(k => k.KilledSide != k.KillerSide) - TeamKillCount - SuicideCount;
+			KillCount = Kills.Count(k => k.KilledSide != k.KillerSide) - SuicideCount;
 			HeadshotCount = Kills.Count(k => k.KilledSide != k.KillerSide && k.IsHeadshot);
 			CrouchKillCount = Kills.Count(k => k.KilledSide != k.KillerSide && k.IsKillerCrouching);
 			JumpKillCount = Kills.Count(k => k.KilledSide != k.KillerSide && k.KillerVelocityZ > 0);


### PR DESCRIPTION
Fixed double subtraction of teamkills, resulting in a wrong kill count (Issue #233)