### PR TITLE
feat(watch): generate vdm for "watch player"

### DIFF
--- a/Manager/Manager.csproj
+++ b/Manager/Manager.csproj
@@ -105,6 +105,12 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
+    <Reference Include="Telerik.Windows.Controls, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.Chart, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.Data, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.DataVisualization, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.Input, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Data, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="Telerik.Windows.Controls, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="Telerik.Windows.Controls.Chart, Version=2018.3.911.40, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="Telerik.Windows.Controls.Data, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />

--- a/Manager/Manager.csproj
+++ b/Manager/Manager.csproj
@@ -105,12 +105,12 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="Telerik.Windows.Controls, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.Chart, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.Data, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.DataVisualization, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.Input, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Data, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.Chart, Version=2018.3.911.40, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.Data, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.DataVisualization, Version=2018.3.911.40, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Controls.Input, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
+    <Reference Include="Telerik.Windows.Data, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="UIAutomationProvider" />
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />

--- a/Manager/Manager.csproj
+++ b/Manager/Manager.csproj
@@ -111,12 +111,6 @@
     <Reference Include="Telerik.Windows.Controls.DataVisualization, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="Telerik.Windows.Controls.Input, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="Telerik.Windows.Data, Version=2018.2.620.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.Chart, Version=2018.3.911.40, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.Data, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.DataVisualization, Version=2018.3.911.40, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Controls.Input, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
-    <Reference Include="Telerik.Windows.Data, Version=2018.3.911.45, Culture=neutral, PublicKeyToken=5803cfa389c90ce7, processorArchitecture=MSIL" />
     <Reference Include="UIAutomationProvider" />
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />

--- a/Manager/ViewModel/Demos/DemoDetailsViewModel.cs
+++ b/Manager/ViewModel/Demos/DemoDetailsViewModel.cs
@@ -530,7 +530,7 @@ namespace Manager.ViewModel.Demos
 								FocusPlayerSteamId = player.SteamId,
 							};
 							GameLauncher launcher = new GameLauncher(config);
-							launcher.WatchDemoAt(firstRound.Tick);
+							launcher.WatchPlayer();
 						},
 						suspect => SelectedPlayer != null));
 			}

--- a/Services/Concrete/GameLauncher.cs
+++ b/Services/Concrete/GameLauncher.cs
@@ -27,7 +27,8 @@ namespace Services.Concrete
 		private const int STUFF_BEGIN_DELAY = 5; // Seconds before the playback start playing and focus on the player
 		private const int STUFF_END_DELAY = 3; // Seconds before the playback fast forward to the next stuff when the previous one is done
 		private const int MOLOTOV_TIME = 8; // Seconds average waiting time for a molotov end
-		private const string ARGUMENT_SEPARATOR = " ";
+        private const int BEGIN_ROUND_SKIP = 10; // Seconds to skip at the beginning of the round when watching player
+        private const string ARGUMENT_SEPARATOR = " ";
 		/// <summary>
 		/// Launcher configuration
 		/// </summary>
@@ -227,7 +228,14 @@ namespace Services.Concrete
 			await StartGame();
 		}
 
-		private void GeneratePlayerStuffVdm(Player player, EquipmentElement type)
+        public async void WatchPlayer()
+        {
+            GenerateWatchPlayerVdm();
+            _config.DeleteVdmFileAtStratup = false;
+            await StartGame();
+        }
+
+        private void GeneratePlayerStuffVdm(Player player, EquipmentElement type)
 		{
 			Demo demo = _config.Demo;
 			string generated = string.Empty;
@@ -422,7 +430,71 @@ namespace Services.Concrete
 			File.WriteAllText(demo.GetVdmFilePath(), content);
 		}
 
-		private static string GetFastForwardMessage(EquipmentElement type)
+        private void GenerateWatchPlayerVdm()
+        {
+            if (_config.FocusPlayerSteamId <= 0)
+                throw new Exception("SteamID required to generate player review.");
+
+            Demo demo = _config.Demo;
+            int nextTick = 0;
+            int startTick = 0;
+            int actionCount = 0;
+            string generated = string.Empty;
+            int nextActionDelayCount = (int)(demo.ServerTickrate * NEXT_ACTION_DELAY);
+            int skipBeginningRoundCount = (int)(demo.ServerTickrate * BEGIN_ROUND_SKIP);
+
+            var playerDeaths = demo.Kills.Where(k => k.KilledSteamId == _config.FocusPlayerSteamId);
+
+            nextTick = demo.Rounds[0].Tick + skipBeginningRoundCount;
+            generated += string.Format(Properties.Resources.skip_ahead, ++actionCount, 1, nextTick);
+            generated += string.Format(Properties.Resources.spec_player, ++actionCount, nextTick + 1, _config.FocusPlayerSteamId);
+            generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 2, "demo_timescale 5");
+            generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 0.5 * skipBeginningRoundCount, "demo_timescale 2");
+            generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 1 * skipBeginningRoundCount, "demo_timescale 1");
+
+            foreach (Round r in demo.Rounds)
+            {
+                // last round and player doesn't get killed
+                if (r.Number == demo.Rounds.Count && !playerDeaths.Any(k => k.RoundNumber == r.Number))
+                {
+                    // end the demo after the round ends
+                    generated += string.Format(Properties.Resources.stop_playback, ++actionCount, r.EndTickOfficially);
+                    break;
+                }
+                // last round and player gets killed
+                else if (r.Number == demo.Rounds.Count)
+                {
+                    // end the demo when the player dies
+                    startTick = playerDeaths.Where(k => k.RoundNumber == r.Number).First().Tick + nextActionDelayCount;
+                    generated += string.Format(Properties.Resources.stop_playback, ++actionCount, startTick);
+                    break;
+                }
+
+                // player dies this round, skip to next round when player dies
+                if (playerDeaths.Any(k => k.RoundNumber == r.Number))
+                {
+                    startTick = playerDeaths.Where(k => k.RoundNumber == r.Number).First().Tick + nextActionDelayCount;
+                    nextTick = r.EndTickOfficially + skipBeginningRoundCount;
+                }
+                // player doesn't die this round, show full round
+                else
+                {
+                    startTick = r.EndTickOfficially;
+                    nextTick = r.EndTickOfficially + skipBeginningRoundCount;
+                }
+
+                // skips ahead and fast forwards through first few seconds of the round
+                generated += string.Format(Properties.Resources.skip_ahead, ++actionCount, startTick, nextTick);
+                generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 1, "demo_timescale 5");
+                generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 0.5 * skipBeginningRoundCount, "demo_timescale 2");
+                generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 1 * skipBeginningRoundCount, "demo_timescale 1");
+            }
+
+            string content = string.Format(Properties.Resources.main, generated);
+            File.WriteAllText(demo.GetVdmFilePath(), content);
+        }
+
+        private static string GetFastForwardMessage(EquipmentElement type)
 		{
 			switch (type)
 			{


### PR DESCRIPTION
Hi Akiver

This generates a vdm so when you choose to watch player it will fast forward through the first few seconds of the round and skip to the next round after the player dies. This is a feature I always wanted and I saw someone else requested this as well.

I was only able to get the newest telerik binaries with a trial account.

Let me know what you think.