### PR TITLE
 fix(watch): freezetime pause does not get skipped

### DIFF
--- a/Services/Concrete/GameLauncher.cs
+++ b/Services/Concrete/GameLauncher.cs
@@ -27,8 +27,7 @@ namespace Services.Concrete
 		private const int STUFF_BEGIN_DELAY = 5; // Seconds before the playback start playing and focus on the player
 		private const int STUFF_END_DELAY = 3; // Seconds before the playback fast forward to the next stuff when the previous one is done
 		private const int MOLOTOV_TIME = 8; // Seconds average waiting time for a molotov end
-		private const int BEGIN_ROUND_SKIP = 10; // Seconds to skip at the beginning of the round when watching player
-		private const string ARGUMENT_SEPARATOR = " ";
+        private const string ARGUMENT_SEPARATOR = " ";
 		/// <summary>
 		/// Launcher configuration
 		/// </summary>
@@ -448,53 +447,34 @@ namespace Services.Concrete
 			int actionCount = 0;
 			string generated = string.Empty;
 			int nextActionDelayCount = (int)(demo.ServerTickrate * NEXT_ACTION_DELAY);
-			int skipBeginningRoundCount = (int)(demo.ServerTickrate * BEGIN_ROUND_SKIP);
 
 			var playerDeaths = demo.Kills.Where(k => k.KilledSteamId == _config.FocusPlayerSteamId);
 
-			nextTick = demo.Rounds[0].Tick + skipBeginningRoundCount;
+			nextTick = demo.Rounds[0].FreezetimeEndTick;
 			generated += string.Format(Properties.Resources.skip_ahead, ++actionCount, 0, nextTick);
 			generated += string.Format(Properties.Resources.spec_player, ++actionCount, nextTick + 1, _config.FocusPlayerSteamId);
-			generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 2, "demo_timescale 5");
-			generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 0.5 * skipBeginningRoundCount, "demo_timescale 2");
-			generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 1 * skipBeginningRoundCount, "demo_timescale 1");
 
 			foreach (Round r in demo.Rounds)
 			{
-				// last round and player doesn't get killed
-				if (r.Number == demo.Rounds.Count && !playerDeaths.Any(k => k.RoundNumber == r.Number))
-				{
-					// end the demo after the round ends
-					generated += string.Format(Properties.Resources.stop_playback, ++actionCount, r.EndTick);
-					break;
-				}
-				// last round and player gets killed
-				else if (r.Number == demo.Rounds.Count)
-				{
-					// end the demo when the player dies
-					startTick = playerDeaths.Where(k => k.RoundNumber == r.Number).First().Tick + nextActionDelayCount;
-					generated += string.Format(Properties.Resources.stop_playback, ++actionCount, startTick);
-					break;
-				}
-
-				// player dies this round, skip to next round when player dies
-				if (playerDeaths.Any(k => k.RoundNumber == r.Number))
+                // last round, don't do anything just let the demo play out
+                if (r.Number == demo.Rounds.Count)
+                    break;
+                
+                // player dies this round, skip to next round after player death
+                if (playerDeaths.Any(k => k.RoundNumber == r.Number))
 				{
 					startTick = playerDeaths.Where(k => k.RoundNumber == r.Number).First().Tick + nextActionDelayCount;
-					nextTick = r.EndTickOfficially + skipBeginningRoundCount;
-				}
+                    nextTick = demo.Rounds[r.Number].FreezetimeEndTick;
+                }
 				// player doesn't die this round, show full round
 				else
 				{
 					startTick = r.EndTickOfficially;
-					nextTick = r.EndTickOfficially + skipBeginningRoundCount;
-				}
+                    nextTick = demo.Rounds[r.Number].FreezetimeEndTick;
+                }
 
-				// skips ahead and fast forwards through first few seconds of the round
+				// skips the freezetime at the beginning of the round
 				generated += string.Format(Properties.Resources.skip_ahead, ++actionCount, startTick, nextTick);
-				generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 1, "demo_timescale 5");
-				generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 0.5 * skipBeginningRoundCount, "demo_timescale 2");
-				generated += string.Format(Properties.Resources.execute_command, ++actionCount, nextTick + 1 * skipBeginningRoundCount, "demo_timescale 1");
 			}
 
 			string content = string.Format(Properties.Resources.main, generated);


### PR DESCRIPTION
Cleans up the logic in GenerateWatchPlayerVdm() so that now:

- Freezetime pauses are skipped
- Demos don't end abruptly
- Early round action won't be fast forwarded through (e.g.: dust2 double doors pick)

 Resolves issue #399 and address issue #403 