### PR TITLE
Added consideration of LastWriteTime

### DIFF
--- a/Services/Concrete/Analyzer/DemoAnalyzer.cs
+++ b/Services/Concrete/Analyzer/DemoAnalyzer.cs
@@ -172,6 +172,10 @@ namespace Services.Concrete.Analyzer
 			DemoParser parser = new DemoParser(File.OpenRead(pathDemoFile));
 
 			DateTime dateFile = File.GetCreationTime(pathDemoFile);
+
+			if (dateFile > File.GetLastWriteTime(pathDemoFile))
+				dateFile = File.GetLastWriteTime(pathDemoFile);
+
 			Demo demo = new Demo
 			{
 				Name = Path.GetFileName(pathDemoFile),


### PR DESCRIPTION
When downloading faceit demos, the LastWriteTime is usually taken from the archive, but the CreationTime is taken when extracted.

This actually results in a "lower" LastWriteTime, than the actual CreationTime and can mix up the demos in the List.

I hope this can be solved with this patch.

Best regards,
