### PR TITLE
refactor: remove UI thread dispatcher calls from demo analyzers

### DIFF
--- a/Core/Models/Demo.cs
+++ b/Core/Models/Demo.cs
@@ -4,11 +4,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System;
-using System.Collections.Specialized;
 using System.Globalization;
 using Core.Models.Events;
 using DemoInfo;
-using GalaSoft.MvvmLight.Threading;
 
 namespace Core.Models
 {
@@ -314,72 +312,72 @@ namespace Core.Models
         /// <summary>
         /// List of rounds during the match
         /// </summary>
-        private ObservableCollection<Round> _rounds;
+        private Collection<Round> _rounds;
 
         /// <summary>
         /// List of players who played during the match
         /// </summary>
-        private ObservableCollection<Player> _players;
+        private Collection<Player> _players;
 
         /// <summary>
         /// Infos on bomb planted during the match
         /// </summary>
-        private ObservableCollection<BombPlantedEvent> _bombPlanted;
+        private Collection<BombPlantedEvent> _bombPlanted;
 
         /// <summary>
         /// Infos on bomb defused during the match
         /// </summary>
-        private ObservableCollection<BombDefusedEvent> _bombDefused;
+        private Collection<BombDefusedEvent> _bombDefused;
 
         /// <summary>
         /// Infos on bomb exploded during the match
         /// </summary>
-        private ObservableCollection<BombExplodedEvent> _bombExploded;
+        private Collection<BombExplodedEvent> _bombExploded;
 
         /// <summary>
         /// Infos about players hurted event
         /// </summary>
-        private ObservableCollection<PlayerHurtedEvent> _playersHurted;
+        private Collection<PlayerHurtedEvent> _playersHurted;
 
         /// <summary>
         /// All kills during the match
         /// </summary>
-        private ObservableCollection<KillEvent> _kills;
+        private Collection<KillEvent> _kills;
 
         /// <summary>
         /// All shots fired during the match
         /// </summary>
-        private ObservableCollection<WeaponFireEvent> _weaponFired;
+        private Collection<WeaponFireEvent> _weaponFired;
 
         /// <summary>
         /// Contains data about flashbangs which had blinded players
         /// </summary>
-        private ObservableCollection<PlayerBlindedEvent> _playerBlinded;
+        private Collection<PlayerBlindedEvent> _playerBlinded;
 
         /// <summary>
         /// Demo's overtimes
         /// </summary>
-        private ObservableCollection<Overtime> _overtimes;
+        private Collection<Overtime> _overtimes;
 
         /// <summary>
         /// Contains all PositionPoint for overview generation
         /// </summary>
-        private ObservableCollection<PositionPoint> _positionPoints;
+        private Collection<PositionPoint> _positionPoints;
 
         /// <summary>
         /// Decoy started events data
         /// </summary>
-        private ObservableCollection<DecoyStartedEvent> _decoysStarted;
+        private Collection<DecoyStartedEvent> _decoysStarted;
 
         /// <summary>
         /// Molotov fire started events data
         /// </summary>
-        private ObservableCollection<MolotovFireStartedEvent> _molotovsFireStarted;
+        private Collection<MolotovFireStartedEvent> _molotovsFireStarted;
 
         /// <summary>
         /// Incendiary fire started events data
         /// </summary>
-        private ObservableCollection<MolotovFireStartedEvent> _incendiariesFireStarted;
+        private Collection<MolotovFireStartedEvent> _incendiariesFireStarted;
 
         /// <summary>
         /// Player with the best HS ratio
@@ -400,6 +398,8 @@ namespace Core.Models
         /// Weapon with the most kills
         /// </summary>
         private Weapon _mostKillingWeapon;
+
+        private Weapon _mostDamagingWeapon;
 
         /// <summary>
         /// Team that started as Counter-Terrorists
@@ -503,11 +503,7 @@ namespace Core.Models
         public float Duration
         {
             get { return _duration; }
-            set
-            {
-                Set(() => Duration, ref _duration, value);
-                RaisePropertyChanged(() => DurationTime);
-            }
+            set { Set(() => Duration, ref _duration, value); }
         }
 
         [JsonProperty("ticks")]
@@ -633,11 +629,7 @@ namespace Core.Models
         public Team Surrender
         {
             get { return _surrender; }
-            set
-            {
-                Set(() => Surrender, ref _surrender, value);
-                RaisePropertyChanged(() => Surrender);
-            }
+            set { Set(() => Surrender, ref _surrender, value); }
         }
 
         [JsonProperty("team_winner", IsReference = true)]
@@ -648,14 +640,14 @@ namespace Core.Models
         }
 
         [JsonProperty("rounds", IsReference = false)]
-        public ObservableCollection<Round> Rounds
+        public Collection<Round> Rounds
         {
             get { return _rounds; }
             set { Set(() => Rounds, ref _rounds, value); }
         }
 
         [JsonProperty("players", IsReference = false)]
-        public ObservableCollection<Player> Players
+        public Collection<Player> Players
         {
             get { return _players; }
             set { Set(() => Players, ref _players, value); }
@@ -668,8 +660,15 @@ namespace Core.Models
             set { Set(() => MostKillingWeapon, ref _mostKillingWeapon, value); }
         }
 
+        [JsonProperty("most_damaging_weapon")]
+        public Weapon MostDamagingWeapon
+        {
+            get { return _mostDamagingWeapon; }
+            set { Set(() => MostDamagingWeapon, ref _mostDamagingWeapon, value); }
+        }
+
         [JsonProperty("overtimes", IsReference = false)]
-        public ObservableCollection<Overtime> Overtimes
+        public Collection<Overtime> Overtimes
         {
             get { return _overtimes; }
             set { Set(() => Overtimes, ref _overtimes, value); }
@@ -697,49 +696,49 @@ namespace Core.Models
         }
 
         [JsonProperty("bomb_planted", IsReference = false)]
-        public ObservableCollection<BombPlantedEvent> BombPlanted
+        public Collection<BombPlantedEvent> BombPlanted
         {
             get { return _bombPlanted; }
             set { Set(() => BombPlanted, ref _bombPlanted, value); }
         }
 
         [JsonProperty("bomb_defused", IsReference = false)]
-        public ObservableCollection<BombDefusedEvent> BombDefused
+        public Collection<BombDefusedEvent> BombDefused
         {
             get { return _bombDefused; }
             set { Set(() => BombDefused, ref _bombDefused, value); }
         }
 
         [JsonProperty("bomb_exploded", IsReference = false)]
-        public ObservableCollection<BombExplodedEvent> BombExploded
+        public Collection<BombExplodedEvent> BombExploded
         {
             get { return _bombExploded; }
             set { Set(() => BombExploded, ref _bombExploded, value); }
         }
 
         [JsonProperty("kills", IsReference = false)]
-        public ObservableCollection<KillEvent> Kills
+        public Collection<KillEvent> Kills
         {
             get { return _kills; }
             set { Set(() => Kills, ref _kills, value); }
         }
 
         [JsonProperty("weapon_fired", IsReference = false)]
-        public ObservableCollection<WeaponFireEvent> WeaponFired
+        public Collection<WeaponFireEvent> WeaponFired
         {
             get { return _weaponFired; }
             set { Set(() => WeaponFired, ref _weaponFired, value); }
         }
 
         [JsonProperty("player_blinded_events", IsReference = false)]
-        public ObservableCollection<PlayerBlindedEvent> PlayerBlinded
+        public Collection<PlayerBlindedEvent> PlayerBlinded
         {
             get { return _playerBlinded; }
             set { Set(() => PlayerBlinded, ref _playerBlinded, value); }
         }
 
         [JsonProperty("player_hurted", IsReference = false)]
-        public ObservableCollection<PlayerHurtedEvent> PlayersHurted
+        public Collection<PlayerHurtedEvent> PlayersHurted
         {
             get { return _playersHurted; }
             set { Set(() => PlayersHurted, ref _playersHurted, value); }
@@ -852,28 +851,28 @@ namespace Core.Models
         }
 
         [JsonIgnore]
-        public ObservableCollection<PositionPoint> PositionPoints
+        public Collection<PositionPoint> PositionPoints
         {
             get { return _positionPoints; }
             set { Set(() => PositionPoints, ref _positionPoints, value); }
         }
 
         [JsonProperty("decoys")]
-        public ObservableCollection<DecoyStartedEvent> DecoyStarted
+        public Collection<DecoyStartedEvent> DecoyStarted
         {
             get { return _decoysStarted; }
             set { Set(() => DecoyStarted, ref _decoysStarted, value); }
         }
 
         [JsonProperty("incendiaries")]
-        public ObservableCollection<MolotovFireStartedEvent> IncendiariesFireStarted
+        public Collection<MolotovFireStartedEvent> IncendiariesFireStarted
         {
             get { return _incendiariesFireStarted; }
             set { Set(() => IncendiariesFireStarted, ref _incendiariesFireStarted, value); }
         }
 
         [JsonProperty("molotovs")]
-        public ObservableCollection<MolotovFireStartedEvent> MolotovsFireStarted
+        public Collection<MolotovFireStartedEvent> MolotovsFireStarted
         {
             get { return _molotovsFireStarted; }
             set { Set(() => MolotovsFireStarted, ref _molotovsFireStarted, value); }
@@ -891,29 +890,6 @@ namespace Core.Models
         {
             get { return _damageArmorCount; }
             set { Set(() => DamageArmorCount, ref _damageArmorCount, value); }
-        }
-
-        [JsonIgnore]
-        public Weapon MostDamageWeapon
-        {
-            get
-            {
-                Dictionary<Weapon, int> weapons = new Dictionary<Weapon, int>();
-
-                foreach (PlayerHurtedEvent playerHurtedEvent in Rounds.SelectMany(round => round.PlayersHurted))
-                {
-                    if (!weapons.ContainsKey(playerHurtedEvent.Weapon))
-                    {
-                        weapons[playerHurtedEvent.Weapon] = playerHurtedEvent.HealthDamage + playerHurtedEvent.ArmorDamage;
-                    }
-                    else
-                    {
-                        weapons[playerHurtedEvent.Weapon] += playerHurtedEvent.HealthDamage + playerHurtedEvent.ArmorDamage;
-                    }
-                }
-
-                return weapons.OrderByDescending(x => x.Value).FirstOrDefault().Key;
-            }
         }
 
         [JsonProperty("average_health_damage")]
@@ -1067,20 +1043,20 @@ namespace Core.Models
 
         public Demo()
         {
-            Kills = new ObservableCollection<KillEvent>();
-            Players = new ObservableCollection<Player>();
-            Rounds = new ObservableCollection<Round>();
-            MolotovsFireStarted = new ObservableCollection<MolotovFireStartedEvent>();
-            IncendiariesFireStarted = new ObservableCollection<MolotovFireStartedEvent>();
-            DecoyStarted = new ObservableCollection<DecoyStartedEvent>();
-            WeaponFired = new ObservableCollection<WeaponFireEvent>();
-            PlayersHurted = new ObservableCollection<PlayerHurtedEvent>();
-            PositionPoints = new ObservableCollection<PositionPoint>();
-            BombExploded = new ObservableCollection<BombExplodedEvent>();
-            BombPlanted = new ObservableCollection<BombPlantedEvent>();
-            BombDefused = new ObservableCollection<BombDefusedEvent>();
-            PlayerBlinded = new ObservableCollection<PlayerBlindedEvent>();
-            Overtimes = new ObservableCollection<Overtime>();
+            Kills = new Collection<KillEvent>();
+            Players = new Collection<Player>();
+            Rounds = new Collection<Round>();
+            MolotovsFireStarted = new Collection<MolotovFireStartedEvent>();
+            IncendiariesFireStarted = new Collection<MolotovFireStartedEvent>();
+            DecoyStarted = new Collection<DecoyStartedEvent>();
+            WeaponFired = new Collection<WeaponFireEvent>();
+            PlayersHurted = new Collection<PlayerHurtedEvent>();
+            PositionPoints = new Collection<PositionPoint>();
+            BombExploded = new Collection<BombExplodedEvent>();
+            BombPlanted = new Collection<BombPlantedEvent>();
+            BombDefused = new Collection<BombDefusedEvent>();
+            PlayerBlinded = new Collection<PlayerBlindedEvent>();
+            Overtimes = new Collection<Overtime>();
             ChatMessageList = new List<string>();
 
             _teamCt = new Team
@@ -1093,13 +1069,6 @@ namespace Core.Models
                 Name = "Team 2",
                 CurrentSide = Side.Terrorist,
             };
-            Kills.CollectionChanged += OnKillsCollectionChanged;
-            BombExploded.CollectionChanged += OnBombExplodedCollectionChanged;
-            BombDefused.CollectionChanged += OnBombDefusedCollectionChanged;
-            BombPlanted.CollectionChanged += OnBombPlantedCollectionChanged;
-            Rounds.CollectionChanged += OnRoundsCollectionChanged;
-            PlayersHurted.CollectionChanged += OnPlayersHurtedCollectionChanged;
-            WeaponFired.CollectionChanged += OnWeaponFireCollectionChanged;
         }
 
         public override bool Equals(object obj)
@@ -1167,6 +1136,7 @@ namespace Core.Models
                 MostBombPlantedPlayer = MostBombPlantedPlayer,
                 MostEntryKillPlayer = MostEntryKillPlayer,
                 MostHeadshotPlayer = MostHeadshotPlayer,
+                MostDamagingWeapon = MostDamagingWeapon,
                 MvpCount = MvpCount,
                 Path = Path,
                 ServerTickrate = ServerTickrate,
@@ -1182,21 +1152,21 @@ namespace Core.Models
                 WeaponFiredCount = WeaponFiredCount,
                 Winner = Winner,
                 WinStatus = WinStatus,
-                Players = new ObservableCollection<Player>(),
-                WeaponFired = new ObservableCollection<WeaponFireEvent>(),
-                DecoyStarted = new ObservableCollection<DecoyStartedEvent>(),
-                BombDefused = new ObservableCollection<BombDefusedEvent>(),
-                BombExploded = new ObservableCollection<BombExplodedEvent>(),
-                BombPlanted = new ObservableCollection<BombPlantedEvent>(),
-                MolotovsFireStarted = new ObservableCollection<MolotovFireStartedEvent>(),
-                IncendiariesFireStarted = new ObservableCollection<MolotovFireStartedEvent>(),
+                Players = new Collection<Player>(),
+                WeaponFired = new Collection<WeaponFireEvent>(),
+                DecoyStarted = new Collection<DecoyStartedEvent>(),
+                BombDefused = new Collection<BombDefusedEvent>(),
+                BombExploded = new Collection<BombExplodedEvent>(),
+                BombPlanted = new Collection<BombPlantedEvent>(),
+                MolotovsFireStarted = new Collection<MolotovFireStartedEvent>(),
+                IncendiariesFireStarted = new Collection<MolotovFireStartedEvent>(),
                 ChatMessageList = new List<string>(),
-                PlayersHurted = new ObservableCollection<PlayerHurtedEvent>(),
-                Kills = new ObservableCollection<KillEvent>(),
-                PlayerBlinded = new ObservableCollection<PlayerBlindedEvent>(),
-                PositionPoints = new ObservableCollection<PositionPoint>(),
-                Overtimes = new ObservableCollection<Overtime>(),
-                Rounds = new ObservableCollection<Round>(),
+                PlayersHurted = new Collection<PlayerHurtedEvent>(),
+                Kills = new Collection<KillEvent>(),
+                PlayerBlinded = new Collection<PlayerBlindedEvent>(),
+                PositionPoints = new Collection<PositionPoint>(),
+                Overtimes = new Collection<Overtime>(),
+                Rounds = new Collection<Round>(),
             };
 
             foreach (Player player in Players)
@@ -1415,6 +1385,7 @@ namespace Core.Models
             MostEntryKillPlayer = demo.MostEntryKillPlayer;
             MostHeadshotPlayer = demo.MostHeadshotPlayer;
             MostKillingWeapon = demo.MostKillingWeapon;
+            MostDamagingWeapon = demo.MostDamagingWeapon;
             MvpCount = demo.MvpCount;
             OneKillCount = demo.OneKillCount;
             SmokeThrownCount = demo.SmokeThrownCount;
@@ -1429,88 +1400,86 @@ namespace Core.Models
 
         public void ResetStats(bool resetTeams = true)
         {
-            DispatcherHelper.CheckBeginInvokeOnUI(delegate
+            AssistCount = 0;
+            AssistPerRound = 0;
+            AverageEseaRws = 0;
+            AverageHealthDamage = 0;
+            AverageHltvRating = 0;
+            AverageHltv2Rating = 0;
+            BombDefusedCount = 0;
+            BombExplodedCount = 0;
+            BombPlantedCount = 0;
+            ClutchCount = 0;
+            ClutchLostCount = 0;
+            ClutchWonCount = 0;
+            CrouchKillCount = 0;
+            DamageArmorCount = 0;
+            DamageHealthCount = 0;
+            DeathCount = 0;
+            DeathPerRound = 0;
+            DecoyThrownCount = 0;
+            EntryKillCount = 0;
+            FlashbangThrownCount = 0;
+            FiveKillCount = 0;
+            FourKillCount = 0;
+            CheaterCount = 0;
+            HeadshotCount = 0;
+            HeThrownCount = 0;
+            HitCount = 0;
+            IncendiaryThrownCount = 0;
+            JumpKillCount = 0;
+            KillCount = 0;
+            KillPerRound = 0;
+            KnifeKillCount = 0;
+            MolotovThrownCount = 0;
+            MostBombPlantedPlayer = null;
+            MostEntryKillPlayer = null;
+            MostHeadshotPlayer = null;
+            MostKillingWeapon = null;
+            MostDamagingWeapon = null;
+            MvpCount = 0;
+            OneKillCount = 0;
+            SmokeThrownCount = 0;
+            Surrender = null;
+            TeamKillCount = 0;
+            ThreeKillCount = 0;
+            TradeKillCount = 0;
+            TwoKillCount = 0;
+            WeaponFiredCount = 0;
+            Winner = null;
+            BombDefused.Clear();
+            BombExploded.Clear();
+            BombPlanted.Clear();
+            ChatMessageList.Clear();
+            DecoyStarted.Clear();
+            IncendiariesFireStarted.Clear();
+            Kills.Clear();
+            MolotovsFireStarted.Clear();
+            Overtimes.Clear();
+            PlayersHurted.Clear();
+            PlayerBlinded.Clear();
+            PositionPoints.Clear();
+            Rounds.Clear();
+            WeaponFired.Clear();
+            TeamT.ResetStats();
+            TeamCT.ResetStats();
+            TeamCT.CurrentSide = Side.CounterTerrorist;
+            TeamT.CurrentSide = Side.Terrorist;
+            if (resetTeams)
             {
-                AssistCount = 0;
-                AssistPerRound = 0;
-                AverageEseaRws = 0;
-                AverageHealthDamage = 0;
-                AverageHltvRating = 0;
-                AverageHltv2Rating = 0;
-                BombDefusedCount = 0;
-                BombExplodedCount = 0;
-                BombPlantedCount = 0;
-                ClutchCount = 0;
-                ClutchLostCount = 0;
-                ClutchWonCount = 0;
-                CrouchKillCount = 0;
-                DamageArmorCount = 0;
-                DamageHealthCount = 0;
-                DeathCount = 0;
-                DeathPerRound = 0;
-                DecoyThrownCount = 0;
-                EntryKillCount = 0;
-                FlashbangThrownCount = 0;
-                FiveKillCount = 0;
-                FourKillCount = 0;
-                CheaterCount = 0;
-                HeadshotCount = 0;
-                HeThrownCount = 0;
-                HitCount = 0;
-                IncendiaryThrownCount = 0;
-                JumpKillCount = 0;
-                KillCount = 0;
-                KillPerRound = 0;
-                KnifeKillCount = 0;
-                MolotovThrownCount = 0;
-                MostBombPlantedPlayer = null;
-                MostEntryKillPlayer = null;
-                MostHeadshotPlayer = null;
-                MostKillingWeapon = null;
-                MvpCount = 0;
-                OneKillCount = 0;
-                SmokeThrownCount = 0;
-                Surrender = null;
-                TeamKillCount = 0;
-                ThreeKillCount = 0;
-                TradeKillCount = 0;
-                TwoKillCount = 0;
-                WeaponFiredCount = 0;
-                Winner = null;
-                BombDefused.Clear();
-                BombExploded.Clear();
-                BombPlanted.Clear();
-                ChatMessageList.Clear();
-                DecoyStarted.Clear();
-                IncendiariesFireStarted.Clear();
-                Kills.Clear();
-                MolotovsFireStarted.Clear();
-                Overtimes.Clear();
-                PlayersHurted.Clear();
-                PlayerBlinded.Clear();
-                PositionPoints.Clear();
-                Rounds.Clear();
-                WeaponFired.Clear();
-                TeamT.ResetStats();
-                TeamCT.ResetStats();
-                TeamCT.CurrentSide = Side.CounterTerrorist;
-                TeamT.CurrentSide = Side.Terrorist;
-                if (resetTeams)
+                Players.Clear();
+                TeamCT.Clear();
+                TeamT.Clear();
+            }
+            else
+            {
+                foreach (Player player in Players)
                 {
-                    Players.Clear();
-                    TeamCT.Clear();
-                    TeamT.Clear();
+                    player.ResetStats();
                 }
-                else
-                {
-                    foreach (Player player in Players)
-                    {
-                        player.ResetStats();
-                    }
-                }
+            }
 
-                RaiseScoresChanged();
-            });
+            RaiseScoresChanged();
         }
 
         /// <summary>
@@ -1532,9 +1501,7 @@ namespace Core.Models
             RaisePropertyChanged(() => ScoreSecondHalfTeamT);
         }
 
-        #region Handler collections changed
-
-        private void OnKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        public void ComputeStats()
         {
             KillCount = Kills.Count;
             DeathCount = Kills.Count;
@@ -1546,31 +1513,13 @@ namespace Core.Models
             JumpKillCount = Kills.Count(killEvent => killEvent.KillerVelocityZ > 0);
             KnifeKillCount = Kills.Count(killEvent => killEvent.Weapon.Element == EquipmentElement.Knife);
             TeamKillCount = Players.Sum(p => p.TeamKillCount);
-        }
-
-        private void OnBombExplodedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             BombExplodedCount = BombExploded.Count;
-        }
-
-        private void OnBombDefusedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             BombDefusedCount = BombDefused.Count;
-        }
-
-        private void OnBombPlantedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             BombPlantedCount = BombPlanted.Count;
-        }
-
-        private void OnRoundsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => MostDamageWeapon);
-            RaisePropertyChanged(() => WinStatus);
-
             ClutchWonCount = Players.Sum(p => p.ClutchWonCount);
             ClutchCount = Players.Sum(p => p.ClutchCount);
             ClutchLostCount = Players.Sum(p => p.ClutchLostCount);
+            MostDamagingWeapon = GetMostDamagingWeapon();
 
             if (Rounds.Any())
             {
@@ -1579,6 +1528,7 @@ namespace Core.Models
                 AssistPerRound = GetAssistPerRound();
                 MvpCount = Players.Sum(p => p.RoundMvpCount);
                 DeathPerRound = Math.Round((double)DeathCount / Rounds.Count, 2);
+                AverageHealthDamage = GetAverageHealthDamage();
             }
 
             if (Players.Any())
@@ -1590,21 +1540,11 @@ namespace Core.Models
                 decimal totalEseaRws = Players.Sum(player => player.EseaRws);
                 AverageEseaRws = Math.Round(totalEseaRws / Players.Count, 2);
             }
-        }
 
-        private void OnPlayersHurtedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             DamageArmorCount = PlayersHurted.Sum(h => h.ArmorDamage);
             DamageHealthCount = PlayersHurted.Sum(h => h.HealthDamage);
             HitCount = PlayersHurted.Count;
-            if (Rounds.Any())
-            {
-                AverageHealthDamage = GetAverageHealthDamage();
-            }
-        }
 
-        private void OnWeaponFireCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             WeaponFiredCount = WeaponFired.Count;
             FlashbangThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Flash);
             SmokeThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Smoke);
@@ -1612,9 +1552,37 @@ namespace Core.Models
             DecoyThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Decoy);
             MolotovThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Molotov);
             IncendiaryThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Incendiary);
+
+            foreach (var player in Players)
+            {
+                player.ComputeStats();
+            }
+
+            foreach (var round in Rounds)
+            {
+                round.ComputeStats();
+            }
         }
 
-        #endregion
+
+        private Weapon GetMostDamagingWeapon()
+        {
+            Dictionary<Weapon, int> weapons = new Dictionary<Weapon, int>();
+
+            foreach (PlayerHurtedEvent playerHurtedEvent in Rounds.SelectMany(round => round.PlayersHurted))
+            {
+                if (!weapons.ContainsKey(playerHurtedEvent.Weapon))
+                {
+                    weapons[playerHurtedEvent.Weapon] = playerHurtedEvent.HealthDamage + playerHurtedEvent.ArmorDamage;
+                }
+                else
+                {
+                    weapons[playerHurtedEvent.Weapon] += playerHurtedEvent.HealthDamage + playerHurtedEvent.ArmorDamage;
+                }
+            }
+
+            return weapons.OrderByDescending(x => x.Value).FirstOrDefault().Key;
+        }
 
         private double GetKillPerRound()
         {

--- a/Core/Models/Player.cs
+++ b/Core/Models/Player.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Linq;
 using Core.Models.Events;
 using Core.Models.Serialization;
@@ -116,11 +115,6 @@ namespace Core.Models
         /// Flag to detect disconnect / reconnect
         /// </summary>
         private bool _isConnected = true;
-
-        /// <summary>
-        /// Player kills / Deaths ratio
-        /// </summary>
-        private decimal _killsDeathsRatio;
 
         /// <summary>
         /// Player's current team side (change when half side is over)
@@ -290,37 +284,37 @@ namespace Core.Models
         /// <summary>
         /// Player's kills data
         /// </summary>
-        private ObservableCollection<KillEvent> _kills;
+        private Collection<KillEvent> _kills;
 
         /// <summary>
         /// Player's deaths data
         /// </summary>
-        private ObservableCollection<KillEvent> _deaths;
+        private Collection<KillEvent> _deaths;
 
         /// <summary>
         /// Player's assists data
         /// </summary>
-        private ObservableCollection<KillEvent> _assists;
+        private Collection<KillEvent> _assists;
 
         /// <summary>
         /// Player's entry kills data
         /// </summary>
-        private ObservableCollection<EntryKillEvent> _entryKills;
+        private Collection<EntryKillEvent> _entryKills;
 
         /// <summary>
         /// Player's entry hold kills data
         /// </summary>
-        private ObservableCollection<EntryHoldKillEvent> _entryHoldKills;
+        private Collection<EntryHoldKillEvent> _entryHoldKills;
 
         /// <summary>
         /// List of PlayerHurtedEvent in which the player is involved
         /// </summary>
-        private ObservableCollection<PlayerHurtedEvent> _playersHurted;
+        private Collection<PlayerHurtedEvent> _playersHurted;
 
         /// <summary>
         /// List of clutches that the player is concerned
         /// </summary>
-        private ObservableCollection<ClutchEvent> _clutches;
+        private Collection<ClutchEvent> _clutches;
 
         #endregion
 
@@ -345,11 +339,7 @@ namespace Core.Models
         public int KillCount
         {
             get { return _killCount; }
-            set
-            {
-                RaisePropertyChanged(() => KillDeathRatio);
-                Set(() => KillCount, ref _killCount, value);
-            }
+            set { Set(() => KillCount, ref _killCount, value); }
         }
 
         [JsonProperty("crouch_kill_count")]
@@ -384,11 +374,7 @@ namespace Core.Models
         public int AssistCount
         {
             get { return _assistCount; }
-            set
-            {
-                Set(() => AssistCount, ref _assistCount, value);
-                RaisePropertyChanged(() => AssistPerRound);
-            }
+            set { Set(() => AssistCount, ref _assistCount, value); }
         }
 
         [JsonProperty("trade_kill_count")]
@@ -430,11 +416,7 @@ namespace Core.Models
         public int DeathCount
         {
             get { return _deathCount; }
-            set
-            {
-                RaisePropertyChanged(() => KillDeathRatio);
-                Set(() => DeathCount, ref _deathCount, value);
-            }
+            set { Set(() => DeathCount, ref _deathCount, value); }
         }
 
         [JsonProperty("5k_count")]
@@ -476,11 +458,7 @@ namespace Core.Models
         public int HeadshotCount
         {
             get { return _headshotCount; }
-            set
-            {
-                Set(() => HeadshotCount, ref _headshotCount, value);
-                RaisePropertyChanged(() => HeadshotPercent);
-            }
+            set { Set(() => HeadshotCount, ref _headshotCount, value); }
         }
 
         [JsonProperty("kd")]
@@ -495,7 +473,6 @@ namespace Core.Models
 
                 return 0;
             }
-            set { Set(() => KillDeathRatio, ref _killsDeathsRatio, value); }
         }
 
         [JsonProperty("mvp_count")]
@@ -537,22 +514,14 @@ namespace Core.Models
         public int ShotCount
         {
             get { return _shotCount; }
-            set
-            {
-                Set(() => ShotCount, ref _shotCount, value);
-                RaisePropertyChanged(() => Accuracy);
-            }
+            set { Set(() => ShotCount, ref _shotCount, value); }
         }
 
         [JsonProperty("hit_count")]
         public int HitCount
         {
             get { return _hitCount; }
-            set
-            {
-                Set(() => HitCount, ref _hitCount, value);
-                RaisePropertyChanged(() => Accuracy);
-            }
+            set { Set(() => HitCount, ref _hitCount, value); }
         }
 
         [JsonIgnore] public double Accuracy => ShotCount == 0 ? 0 : Math.Round(HitCount / (double)ShotCount * 100, 2);
@@ -656,49 +625,49 @@ namespace Core.Models
         }
 
         [JsonProperty("entry_kills")]
-        public ObservableCollection<EntryKillEvent> EntryKills
+        public Collection<EntryKillEvent> EntryKills
         {
             get { return _entryKills; }
             set { Set(() => EntryKills, ref _entryKills, value); }
         }
 
         [JsonProperty("entry_hold_kills")]
-        public ObservableCollection<EntryHoldKillEvent> EntryHoldKills
+        public Collection<EntryHoldKillEvent> EntryHoldKills
         {
             get { return _entryHoldKills; }
             set { Set(() => EntryHoldKills, ref _entryHoldKills, value); }
         }
 
         [JsonProperty("kills", IsReference = false)]
-        public ObservableCollection<KillEvent> Kills
+        public Collection<KillEvent> Kills
         {
             get { return _kills; }
             set { Set(() => Kills, ref _kills, value); }
         }
 
         [JsonProperty("deaths", IsReference = false)]
-        public ObservableCollection<KillEvent> Deaths
+        public Collection<KillEvent> Deaths
         {
             get { return _deaths; }
             set { Set(() => Deaths, ref _deaths, value); }
         }
 
         [JsonProperty("assits", IsReference = false)]
-        public ObservableCollection<KillEvent> Assists
+        public Collection<KillEvent> Assists
         {
             get { return _assists; }
             set { Set(() => Assists, ref _assists, value); }
         }
 
         [JsonProperty("players_hurted")]
-        public ObservableCollection<PlayerHurtedEvent> PlayersHurted
+        public Collection<PlayerHurtedEvent> PlayersHurted
         {
             get { return _playersHurted; }
             set { Set(() => PlayersHurted, ref _playersHurted, value); }
         }
 
         [JsonProperty("clutches")]
-        public ObservableCollection<ClutchEvent> Clutches
+        public Collection<ClutchEvent> Clutches
         {
             get { return _clutches; }
             set { Set(() => Clutches, ref _clutches, value); }
@@ -1081,83 +1050,25 @@ namespace Core.Models
 
         public Player()
         {
-            EntryKills = new ObservableCollection<EntryKillEvent>();
-            EntryHoldKills = new ObservableCollection<EntryHoldKillEvent>();
-            PlayersHurted = new ObservableCollection<PlayerHurtedEvent>();
-            Clutches = new ObservableCollection<ClutchEvent>();
-            Kills = new ObservableCollection<KillEvent>();
-            Deaths = new ObservableCollection<KillEvent>();
-            Assists = new ObservableCollection<KillEvent>();
-            Kills.CollectionChanged += OnKillsCollectionChanged;
-            Deaths.CollectionChanged += OnDeathsCollectionChanged;
-            Assists.CollectionChanged += OnAssistsCollectionChanged;
-            EntryKills.CollectionChanged += OnEntryKillsCollectionChanged;
-            EntryHoldKills.CollectionChanged += OnEntryHoldKillsCollectionChanged;
-            PlayersHurted.CollectionChanged += OnPlayersHurtedCollectionChanged;
-            Clutches.CollectionChanged += OnClutchesCollectionChanged;
+            EntryKills = new Collection<EntryKillEvent>();
+            EntryHoldKills = new Collection<EntryHoldKillEvent>();
+            PlayersHurted = new Collection<PlayerHurtedEvent>();
+            Clutches = new Collection<ClutchEvent>();
+            Kills = new Collection<KillEvent>();
+            Deaths = new Collection<KillEvent>();
+            Assists = new Collection<KillEvent>();
             Side = Side.None;
         }
 
-        private void OnAssistsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            AssistCount = Assists.Count;
-        }
-
-        private void OnDeathsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            DeathCount = Deaths.Count + SuicideCount;
-            RaisePropertyChanged(() => AverageTimeDeath);
-        }
-
-        private void OnKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        public void ComputeStats()
         {
             TeamKillCount = Kills.Count(k => k.KilledSide == k.KillerSide);
             KillCount = Kills.Count(k => k.KilledSide != k.KillerSide) - TeamKillCount - SuicideCount;
             HeadshotCount = Kills.Count(k => k.KilledSide != k.KillerSide && k.IsHeadshot);
             CrouchKillCount = Kills.Count(k => k.KilledSide != k.KillerSide && k.IsKillerCrouching);
             JumpKillCount = Kills.Count(k => k.KilledSide != k.KillerSide && k.KillerVelocityZ > 0);
-        }
-
-        private void OnPlayersHurtedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => TotalDamageHealthCount);
-            RaisePropertyChanged(() => TotalDamageArmorCount);
-            RaisePropertyChanged(() => AverageHealthDamage);
-        }
-
-        private void OnEntryKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => EntryKillWonCount);
-            RaisePropertyChanged(() => EntryKillLossCount);
-            RaisePropertyChanged(() => RatioEntryKill);
-        }
-
-        private void OnEntryHoldKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => EntryHoldKillWonCount);
-            RaisePropertyChanged(() => EntryHoldKillLossCount);
-            RaisePropertyChanged(() => RatioEntryHoldKill);
-        }
-
-        private void OnClutchesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => ClutchCount);
-            RaisePropertyChanged(() => ClutchLostCount);
-            RaisePropertyChanged(() => Clutch1V1Count);
-            RaisePropertyChanged(() => Clutch1V2Count);
-            RaisePropertyChanged(() => Clutch1V3Count);
-            RaisePropertyChanged(() => Clutch1V4Count);
-            RaisePropertyChanged(() => Clutch1V5Count);
-            RaisePropertyChanged(() => Clutch1V1WonCount);
-            RaisePropertyChanged(() => Clutch1V2WonCount);
-            RaisePropertyChanged(() => Clutch1V3WonCount);
-            RaisePropertyChanged(() => Clutch1V4WonCount);
-            RaisePropertyChanged(() => Clutch1V5WonCount);
-            RaisePropertyChanged(() => Clutch1V1LossCount);
-            RaisePropertyChanged(() => Clutch1V2LossCount);
-            RaisePropertyChanged(() => Clutch1V3LossCount);
-            RaisePropertyChanged(() => Clutch1V4LossCount);
-            RaisePropertyChanged(() => Clutch1V5LossCount);
+            AssistCount = Assists.Count;
+            DeathCount = Deaths.Count + SuicideCount;
         }
 
         public void ResetStats()
@@ -1253,7 +1164,6 @@ namespace Core.Models
                 IsOverwatchBanned = IsOverwatchBanned,
                 IsVacBanned = IsVacBanned,
                 JumpKillCount = JumpKillCount,
-                KillDeathRatio = KillDeathRatio,
                 MolotovThrownCount = MolotovThrownCount,
                 RankNumberNew = RankNumberNew,
                 RankNumberOld = RankNumberOld,
@@ -1269,14 +1179,14 @@ namespace Core.Models
                 TradeDeathCount = TradeDeathCount,
                 TradeKillCount = TradeKillCount,
                 WinCount = WinCount,
-                PlayersHurted = new ObservableCollection<PlayerHurtedEvent>(),
-                Kills = new ObservableCollection<KillEvent>(),
-                Assists = new ObservableCollection<KillEvent>(),
-                Deaths = new ObservableCollection<KillEvent>(),
-                EntryHoldKills = new ObservableCollection<EntryHoldKillEvent>(),
+                PlayersHurted = new Collection<PlayerHurtedEvent>(),
+                Kills = new Collection<KillEvent>(),
+                Assists = new Collection<KillEvent>(),
+                Deaths = new Collection<KillEvent>(),
+                EntryHoldKills = new Collection<EntryHoldKillEvent>(),
                 RoundsMoneyEarned = new Dictionary<int, int>(),
-                Clutches = new ObservableCollection<ClutchEvent>(),
-                EntryKills = new ObservableCollection<EntryKillEvent>(),
+                Clutches = new Collection<ClutchEvent>(),
+                EntryKills = new Collection<EntryKillEvent>(),
                 EquipementValueRounds = new Dictionary<int, int>(),
                 StartMoneyRounds = new Dictionary<int, int>(),
             };

--- a/Core/Models/Round.cs
+++ b/Core/Models/Round.cs
@@ -2,7 +2,6 @@ using System;
 using GalaSoft.MvvmLight;
 using Newtonsoft.Json;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Linq;
 using Core.Models.Events;
 using Core.Models.Serialization;
@@ -291,32 +290,32 @@ namespace Core.Models
         /// <summary>
         /// Kills done during the round
         /// </summary>
-        private ObservableCollection<KillEvent> _kills;
+        private Collection<KillEvent> _kills;
 
         /// <summary>
         /// Infos about flashbangs exploded events
         /// </summary>
-        private ObservableCollection<FlashbangExplodedEvent> _flashbangsExploded;
+        private Collection<FlashbangExplodedEvent> _flashbangsExploded;
 
         /// <summary>
         /// Infos about HE Grenades that exploded during the round
         /// </summary>
-        private ObservableCollection<ExplosiveNadeExplodedEvent> _explosiveGrenadesExploded;
+        private Collection<ExplosiveNadeExplodedEvent> _explosiveGrenadesExploded;
 
         /// <summary>
         /// Infos about smokes poped during the round
         /// </summary>
-        private ObservableCollection<SmokeNadeStartedEvent> _smokeStarted;
+        private Collection<SmokeNadeStartedEvent> _smokeStarted;
 
         /// <summary>
         /// Infos on players damages made during the round
         /// </summary>
-        private ObservableCollection<PlayerHurtedEvent> _playerHurted;
+        private Collection<PlayerHurtedEvent> _playerHurted;
 
         /// <summary>
         /// Infos about shoots done during the round
         /// </summary>
-        private ObservableCollection<WeaponFireEvent> _weaponFired;
+        private Collection<WeaponFireEvent> _weaponFired;
 
         #endregion
 
@@ -366,7 +365,7 @@ namespace Core.Models
         }
 
         [JsonProperty("kills", IsReference = false)]
-        public ObservableCollection<KillEvent> Kills
+        public Collection<KillEvent> Kills
         {
             get { return _kills; }
             set { Set(() => Kills, ref _kills, value); }
@@ -613,14 +612,14 @@ namespace Core.Models
         }
 
         [JsonProperty("players_hurted", IsReference = false)]
-        public ObservableCollection<PlayerHurtedEvent> PlayersHurted
+        public Collection<PlayerHurtedEvent> PlayersHurted
         {
             get { return _playerHurted; }
             set { Set(() => PlayersHurted, ref _playerHurted, value); }
         }
 
         [JsonProperty("weapon_fired", IsReference = false)]
-        public ObservableCollection<WeaponFireEvent> WeaponFired
+        public Collection<WeaponFireEvent> WeaponFired
         {
             get { return _weaponFired; }
             set { Set(() => WeaponFired, ref _weaponFired, value); }
@@ -655,21 +654,21 @@ namespace Core.Models
         }
 
         [JsonProperty("flashbangs_exploded")]
-        public ObservableCollection<FlashbangExplodedEvent> FlashbangsExploded
+        public Collection<FlashbangExplodedEvent> FlashbangsExploded
         {
             get { return _flashbangsExploded; }
             set { Set(() => FlashbangsExploded, ref _flashbangsExploded, value); }
         }
 
         [JsonProperty("smokes_started")]
-        public ObservableCollection<SmokeNadeStartedEvent> SmokeStarted
+        public Collection<SmokeNadeStartedEvent> SmokeStarted
         {
             get { return _smokeStarted; }
             set { Set(() => SmokeStarted, ref _smokeStarted, value); }
         }
 
         [JsonProperty("he_exploded")]
-        public ObservableCollection<ExplosiveNadeExplodedEvent> ExplosiveGrenadesExploded
+        public Collection<ExplosiveNadeExplodedEvent> ExplosiveGrenadesExploded
         {
             get { return _explosiveGrenadesExploded; }
             set { Set(() => ExplosiveGrenadesExploded, ref _explosiveGrenadesExploded, value); }
@@ -679,16 +678,12 @@ namespace Core.Models
 
         public Round()
         {
-            PlayersHurted = new ObservableCollection<PlayerHurtedEvent>();
-            WeaponFired = new ObservableCollection<WeaponFireEvent>();
-            ExplosiveGrenadesExploded = new ObservableCollection<ExplosiveNadeExplodedEvent>();
-            SmokeStarted = new ObservableCollection<SmokeNadeStartedEvent>();
-            FlashbangsExploded = new ObservableCollection<FlashbangExplodedEvent>();
-            Kills = new ObservableCollection<KillEvent>();
-
-            Kills.CollectionChanged += OnKillsCollectionChanged;
-            PlayersHurted.CollectionChanged += OnPlayersHurtedCollectionChanged;
-            WeaponFired.CollectionChanged += OnWeaponFiredCollectionChanged;
+            PlayersHurted = new Collection<PlayerHurtedEvent>();
+            WeaponFired = new Collection<WeaponFireEvent>();
+            ExplosiveGrenadesExploded = new Collection<ExplosiveNadeExplodedEvent>();
+            SmokeStarted = new Collection<SmokeNadeStartedEvent>();
+            FlashbangsExploded = new Collection<FlashbangExplodedEvent>();
+            Kills = new Collection<KillEvent>();
         }
 
         public override bool Equals(object obj)
@@ -751,12 +746,12 @@ namespace Core.Models
                 Type = Type,
                 WinnerName = WinnerName,
                 WinnerSide = WinnerSide,
-                PlayersHurted = new ObservableCollection<PlayerHurtedEvent>(),
-                Kills = new ObservableCollection<KillEvent>(),
-                WeaponFired = new ObservableCollection<WeaponFireEvent>(),
-                ExplosiveGrenadesExploded = new ObservableCollection<ExplosiveNadeExplodedEvent>(),
-                FlashbangsExploded = new ObservableCollection<FlashbangExplodedEvent>(),
-                SmokeStarted = new ObservableCollection<SmokeNadeStartedEvent>(),
+                PlayersHurted = new Collection<PlayerHurtedEvent>(),
+                Kills = new Collection<KillEvent>(),
+                WeaponFired = new Collection<WeaponFireEvent>(),
+                ExplosiveGrenadesExploded = new Collection<ExplosiveNadeExplodedEvent>(),
+                FlashbangsExploded = new Collection<FlashbangExplodedEvent>(),
+                SmokeStarted = new Collection<SmokeNadeStartedEvent>(),
             };
 
             foreach (PlayerHurtedEvent e in PlayersHurted)
@@ -835,9 +830,7 @@ namespace Core.Models
             WeaponFired.Clear();
         }
 
-        #region Handler collections changed
-
-        private void OnKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        public void ComputeStats()
         {
             KillCount = Kills.Count;
             JumpKillCount = Kills.Count(killEvent => killEvent.KillerVelocityZ > 0);
@@ -856,19 +849,11 @@ namespace Core.Models
             ThreeKillCount = kills.Count(k => k.KillCount == 3);
             FourKillCount = kills.Count(k => k.KillCount == 4);
             FiveKillCount = kills.Count(k => k.KillCount == 5);
-        }
-
-        private void OnPlayersHurtedCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             DamageHealthCount = PlayersHurted.Where(playerHurtedEvent => playerHurtedEvent.AttackerSteamId != 0)
                 .Sum(playerHurtedEvent => playerHurtedEvent.HealthDamage);
             DamageArmorCount = PlayersHurted.Where(playerHurtedEvent => playerHurtedEvent.AttackerSteamId != 0)
                 .Sum(playerHurtedEvent => playerHurtedEvent.ArmorDamage);
             AverageHealthDamagePerPlayer = GetAverageHealthDamagePerPlayer();
-        }
-
-        private void OnWeaponFiredCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
             IncendiaryThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Incendiary);
             MolotovThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Molotov);
             DecoyThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Decoy);
@@ -876,8 +861,6 @@ namespace Core.Models
             SmokeThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Smoke);
             FlashbangThrownCount = WeaponFired.Count(w => w.Weapon.Element == EquipmentElement.Flash);
         }
-
-        #endregion
 
         private double GetAverageHealthDamagePerPlayer()
         {

--- a/Core/Models/Team.cs
+++ b/Core/Models/Team.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Linq;
 using GalaSoft.MvvmLight;
 using Newtonsoft.Json;
@@ -52,7 +51,7 @@ namespace Core.Models
         }
 
         [JsonProperty("team_players", IsReference = false)]
-        public ObservableCollection<Player> Players { get; set; }
+        public Collection<Player> Players { get; set; }
 
         [JsonIgnore] public Side CurrentSide { get; set; }
 
@@ -231,8 +230,7 @@ namespace Core.Models
 
         public Team()
         {
-            Players = new ObservableCollection<Player>();
-            Players.CollectionChanged += OnPlayersCollectionChanged;
+            Players = new Collection<Player>();
         }
 
         public void Clear()
@@ -291,7 +289,7 @@ namespace Core.Models
                 WinRoundCtCount = WinRoundCtCount,
                 WinRoundTCount = WinRoundTCount,
                 WinSemiEcoRoundCount = WinSemiEcoRoundCount,
-                Players = new ObservableCollection<Player>(),
+                Players = new Collection<Player>(),
             };
 
             foreach (Player player in Players)
@@ -326,60 +324,5 @@ namespace Core.Models
             WinRoundTCount = team.WinRoundTCount;
             WinSemiEcoRoundCount = team.WinSemiEcoRoundCount;
         }
-
-        #region Collections events
-
-        private void OnPlayersCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            if (Players.Any())
-            {
-                foreach (var player in Players)
-                {
-                    if (player != null)
-                    {
-                        player.Kills.CollectionChanged += OnKillsCollectionChanged;
-                        player.Deaths.CollectionChanged += OnDeathsCollectionChanged;
-                        player.Assists.CollectionChanged += OnAssistsCollectionChanged;
-                        player.EntryKills.CollectionChanged += OnEntryKillsCollectionChanged;
-                        player.EntryHoldKills.CollectionChanged += OnEntryHoldKillsCollectionChanged;
-                    }
-                }
-            }
-        }
-
-        private void OnDeathsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => DeathCount);
-        }
-
-        private void OnAssistsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => AssistCount);
-        }
-
-        private void OnKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => KillCount);
-            RaisePropertyChanged(() => JumpKillCount);
-            RaisePropertyChanged(() => CrouchKillCount);
-        }
-
-        private void OnEntryKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => EntryKillCount);
-            RaisePropertyChanged(() => EntryKillWonCount);
-            RaisePropertyChanged(() => EntryKillLossCount);
-            RaisePropertyChanged(() => RatioEntryKill);
-        }
-
-        private void OnEntryHoldKillsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            RaisePropertyChanged(() => EntryHoldKillCount);
-            RaisePropertyChanged(() => EntryHoldKillWonCount);
-            RaisePropertyChanged(() => EntryHoldKillLossCount);
-            RaisePropertyChanged(() => RatioEntryHoldKill);
-        }
-
-        #endregion
     }
 }

--- a/Manager/ViewModel/Demos/DemoMovieViewModel.cs
+++ b/Manager/ViewModel/Demos/DemoMovieViewModel.cs
@@ -15,7 +15,6 @@ using Core.Models;
 using Core.Models.Source;
 using GalaSoft.MvvmLight.CommandWpf;
 using MahApps.Metro.Controls.Dialogs;
-using Manager.Internals;
 using Manager.Models.DemoMovie;
 using Manager.Properties;
 using Manager.Services;
@@ -1537,7 +1536,7 @@ namespace Manager.ViewModel.Demos
 
         private void InitConfiguration()
         {
-            OutputFileName = Path.GetFileNameWithoutExtension(Demo.Name);
+            OutputFileName = Demo.NameWithoutExtension;
             FrameRate = Settings.Default.MovieFramerate;
             AutoCloseGame = Settings.Default.MovieAutoCloseGame;
             Fullscreen = Settings.Default.MovieFullscreen;

--- a/Manager/Views/Demos/DemoDetailsView.xaml
+++ b/Manager/Views/Demos/DemoDetailsView.xaml
@@ -483,7 +483,7 @@
                                                Margin="5 0 0 0">
                                         <Run Text=" " />
                                     </TextBlock>
-                                    <TextBlock Text="{Binding Demo.MostDamageWeapon.Name}"
+                                    <TextBlock Text="{Binding Demo.MostDamagingWeapon.Name}"
                                                Style="{StaticResource TextBlockSmall}" />
                                 </StackPanel>
                             </StackPanel>

--- a/Services/Concrete/Analyzer/CevoAnalyzer.cs
+++ b/Services/Concrete/Analyzer/CevoAnalyzer.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using Core.Models;
 using DemoInfo;
 using Player = Core.Models.Player;
@@ -81,7 +80,7 @@ namespace Services.Concrete.Analyzer
         protected void HandleWinPanelMatch(object sender, WinPanelMatchEventArgs e)
         {
             // Add the last round (round_officially_ended isn't raised at the end)
-            Application.Current.Dispatcher.Invoke(delegate { Demo.Rounds.Add(CurrentRound); });
+            Demo.Rounds.Add(CurrentRound);
 
             ProcessPlayersRating();
         }
@@ -165,7 +164,7 @@ namespace Services.Concrete.Analyzer
             UpdateKillsCount();
             UpdatePlayerScore();
 
-            Application.Current.Dispatcher.Invoke(delegate { Demo.Rounds.Add(CurrentRound); });
+            Demo.Rounds.Add(CurrentRound);
 
             // End of a half
             if (IsLastRoundHalf)
@@ -183,7 +182,7 @@ namespace Services.Concrete.Analyzer
                 // Add the current overtime only if it's not the first
                 if (CurrentOvertime.Number != 0)
                 {
-                    Application.Current.Dispatcher.Invoke(delegate { Demo.Overtimes.Add(CurrentOvertime); });
+                    Demo.Overtimes.Add(CurrentOvertime);
                     IsHalfMatch = true;
                 }
                 else
@@ -219,31 +218,28 @@ namespace Services.Concrete.Analyzer
                     Side = player.Team.ToSide(),
                 };
 
-                Application.Current.Dispatcher.Invoke(delegate
+                if (!Demo.Players.Contains(pl))
                 {
-                    if (!Demo.Players.Contains(pl))
-                    {
-                        Demo.Players.Add(pl);
-                    }
+                    Demo.Players.Add(pl);
+                }
 
-                    if (pl.Side == Side.CounterTerrorist)
+                if (pl.Side == Side.CounterTerrorist)
+                {
+                    pl.TeamName = Demo.TeamCT.Name;
+                    if (!Demo.TeamCT.Players.Contains(pl))
                     {
-                        pl.TeamName = Demo.TeamCT.Name;
-                        if (!Demo.TeamCT.Players.Contains(pl))
-                        {
-                            Demo.TeamCT.Players.Add(pl);
-                        }
+                        Demo.TeamCT.Players.Add(pl);
                     }
+                }
 
-                    if (pl.Side == Side.Terrorist)
+                if (pl.Side == Side.Terrorist)
+                {
+                    pl.TeamName = Demo.TeamT.Name;
+                    if (!Demo.TeamT.Players.Contains(pl))
                     {
-                        pl.TeamName = Demo.TeamT.Name;
-                        if (!Demo.TeamT.Players.Contains(pl))
-                        {
-                            Demo.TeamT.Players.Add(pl);
-                        }
+                        Demo.TeamT.Players.Add(pl);
                     }
-                });
+                }
             }
         }
     }

--- a/Services/Concrete/Analyzer/EbotAnalyzer.cs
+++ b/Services/Concrete/Analyzer/EbotAnalyzer.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using Core.Models;
 using DemoInfo;
 using Player = Core.Models.Player;
@@ -119,7 +118,7 @@ namespace Services.Concrete.Analyzer
                 // if the number of rounds played is equals to the double of MR, the OT is over
                 if (MrOvertime * 2 == RoundCountOvertime)
                 {
-                    Application.Current.Dispatcher.Invoke(() => Demo.Overtimes.Add(CurrentOvertime));
+                    Demo.Overtimes.Add(CurrentOvertime);
                     CreateNewOvertime();
                     RoundCountOvertime = 0;
                 }
@@ -275,13 +274,10 @@ namespace Services.Concrete.Analyzer
                 UpdatePlayerScore();
             }
 
-            Application.Current.Dispatcher.Invoke(delegate
+            if (!IsOvertime || !_isFaceit)
             {
-                if (!IsOvertime || !_isFaceit)
-                {
-                    Demo.Rounds.Add(CurrentRound);
-                }
-            });
+                Demo.Rounds.Add(CurrentRound);
+            }
 
             IsMatchStarted = false;
         }
@@ -354,7 +350,7 @@ namespace Services.Concrete.Analyzer
 
             if (IsLastRoundHalf)
             {
-                Application.Current.Dispatcher.Invoke(() => Demo.Rounds.Add(CurrentRound));
+                Demo.Rounds.Add(CurrentRound);
             }
         }
 
@@ -364,21 +360,18 @@ namespace Services.Concrete.Analyzer
 
             if (!_isTeamsInitialized)
             {
-                Application.Current.Dispatcher.Invoke(delegate
+                if (Demo.Players.Count < 10)
                 {
-                    if (Demo.Players.Count < 10)
-                    {
-                        InitMatch();
-                    }
+                    InitMatch();
+                }
 
-                    Demo.Rounds.Clear();
-                    CreateNewRound();
-                    // since some demos are already started we can't use the freezetime event
-                    if (CurrentRound.Number == 1)
-                    {
-                        IsFreezetime = false;
-                    }
-                });
+                Demo.Rounds.Clear();
+                CreateNewRound();
+                // since some demos are already started we can't use the freezetime event
+                if (CurrentRound.Number == 1)
+                {
+                    IsFreezetime = false;
+                }
             }
 
             base.HandleTickDone(sender, e);
@@ -456,24 +449,24 @@ namespace Services.Concrete.Analyzer
                         {
                             if (teamT.Players.Contains(pl))
                             {
-                                Application.Current.Dispatcher.Invoke(() => teamT.Players.Remove(pl));
+                                teamT.Players.Remove(pl);
                             }
 
                             if (!teamCt.Players.Contains(pl))
                             {
-                                Application.Current.Dispatcher.Invoke(() => teamCt.Players.Add(pl));
+                                teamCt.Players.Add(pl);
                             }
                         }
                         else if (player.Team == DemoInfo.Team.Terrorist)
                         {
                             if (teamCt.Players.Contains(pl))
                             {
-                                Application.Current.Dispatcher.Invoke(() => teamCt.Players.Remove(pl));
+                                teamCt.Players.Remove(pl);
                             }
 
                             if (!teamT.Players.Contains(pl))
                             {
-                                Application.Current.Dispatcher.Invoke(() => teamT.Players.Add(pl));
+                                teamT.Players.Add(pl);
                             }
                         }
                     }
@@ -486,7 +479,7 @@ namespace Services.Concrete.Analyzer
                             Name = player.Name,
                             Side = player.Team.ToSide(),
                         };
-                        Application.Current.Dispatcher.Invoke(() => Demo.Players.Add(pl));
+                        Demo.Players.Add(pl);
 
                         if (player.Team == DemoInfo.Team.CounterTerrorist)
                         {
@@ -494,17 +487,14 @@ namespace Services.Concrete.Analyzer
                             // Check swap
                             if (Demo.TeamT.Players.Contains(pl))
                             {
-                                Application.Current.Dispatcher.Invoke(delegate
-                                {
-                                    Demo.TeamCT.Players.Add(Demo.TeamT.Players.First(p => p.Equals(pl)));
-                                    Demo.TeamT.Players.Remove(pl);
-                                });
+                                Demo.TeamCT.Players.Add(Demo.TeamT.Players.First(p => p.Equals(pl)));
+                                Demo.TeamT.Players.Remove(pl);
                             }
                             else
                             {
                                 if (!Demo.TeamCT.Players.Contains(pl))
                                 {
-                                    Application.Current.Dispatcher.Invoke(() => Demo.TeamCT.Players.Add(pl));
+                                    Demo.TeamCT.Players.Add(pl);
                                 }
                             }
                         }
@@ -514,17 +504,14 @@ namespace Services.Concrete.Analyzer
                             // Check swap
                             if (Demo.TeamCT.Players.Contains(pl))
                             {
-                                Application.Current.Dispatcher.Invoke(delegate
-                                {
-                                    Demo.TeamT.Players.Add(Demo.TeamCT.Players.First(p => p.Equals(pl)));
-                                    Demo.TeamCT.Players.Remove(pl);
-                                });
+                                Demo.TeamT.Players.Add(Demo.TeamCT.Players.First(p => p.Equals(pl)));
+                                Demo.TeamCT.Players.Remove(pl);
                             }
                             else
                             {
                                 if (!Demo.TeamT.Players.Contains(pl))
                                 {
-                                    Application.Current.Dispatcher.Invoke(() => Demo.TeamT.Players.Add(pl));
+                                    Demo.TeamT.Players.Add(pl);
                                 }
                             }
                         }

--- a/Services/Concrete/Analyzer/EseaAnalyzer.cs
+++ b/Services/Concrete/Analyzer/EseaAnalyzer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using Core.Models;
 using DemoInfo;
 using Player = Core.Models.Player;
@@ -200,7 +199,7 @@ namespace Services.Concrete.Analyzer
                 // if the number of rounds played during OT == 2x MR OT detected, the OT is over
                 if (MrOvertime * 2 == RoundCountOvertime)
                 {
-                    Application.Current.Dispatcher.Invoke(() => Demo.Overtimes.Add(CurrentOvertime));
+                    Demo.Overtimes.Add(CurrentOvertime);
                     CreateNewOvertime();
                     RoundCountOvertime = 0;
                 }
@@ -232,56 +231,53 @@ namespace Services.Concrete.Analyzer
             {
                 if (player.SteamID != 0)
                 {
-                    Application.Current.Dispatcher.Invoke(delegate
+                    Player pl = Demo.Players.FirstOrDefault(p => p.SteamId == player.SteamID);
+                    if (pl == null)
                     {
-                        Player pl = Demo.Players.FirstOrDefault(p => p.SteamId == player.SteamID);
-                        if (pl == null)
+                        pl = new Player
                         {
-                            pl = new Player
-                            {
-                                SteamId = player.SteamID,
-                                Name = player.Name,
-                                Side = player.Team.ToSide(),
-                            };
-                            Demo.Players.Add(pl);
-                        }
+                            SteamId = player.SteamID,
+                            Name = player.Name,
+                            Side = player.Team.ToSide(),
+                        };
+                        Demo.Players.Add(pl);
+                    }
 
-                        if (pl.Side == Side.CounterTerrorist)
+                    if (pl.Side == Side.CounterTerrorist)
+                    {
+                        pl.TeamName = Demo.TeamCT.Name;
+                        // Check swap
+                        if (Demo.TeamT.Players.Contains(pl))
                         {
-                            pl.TeamName = Demo.TeamCT.Name;
-                            // Check swap
-                            if (Demo.TeamT.Players.Contains(pl))
+                            Demo.TeamCT.Players.Add(Demo.TeamT.Players.First(p => p.Equals(pl)));
+                            Demo.TeamT.Players.Remove(pl);
+                        }
+                        else
+                        {
+                            if (!Demo.TeamCT.Players.Contains(pl))
                             {
-                                Demo.TeamCT.Players.Add(Demo.TeamT.Players.First(p => p.Equals(pl)));
-                                Demo.TeamT.Players.Remove(pl);
-                            }
-                            else
-                            {
-                                if (!Demo.TeamCT.Players.Contains(pl))
-                                {
-                                    Demo.TeamCT.Players.Add(pl);
-                                }
+                                Demo.TeamCT.Players.Add(pl);
                             }
                         }
+                    }
 
-                        if (pl.Side == Side.Terrorist)
+                    if (pl.Side == Side.Terrorist)
+                    {
+                        pl.TeamName = Demo.TeamT.Name;
+                        // Check swap
+                        if (Demo.TeamCT.Players.Contains(pl))
                         {
-                            pl.TeamName = Demo.TeamT.Name;
-                            // Check swap
-                            if (Demo.TeamCT.Players.Contains(pl))
+                            Demo.TeamT.Players.Add(Demo.TeamCT.Players.First(p => p.Equals(pl)));
+                            Demo.TeamCT.Players.Remove(pl);
+                        }
+                        else
+                        {
+                            if (!Demo.TeamT.Players.Contains(pl))
                             {
-                                Demo.TeamT.Players.Add(Demo.TeamCT.Players.First(p => p.Equals(pl)));
-                                Demo.TeamCT.Players.Remove(pl);
-                            }
-                            else
-                            {
-                                if (!Demo.TeamT.Players.Contains(pl))
-                                {
-                                    Demo.TeamT.Players.Add(pl);
-                                }
+                                Demo.TeamT.Players.Add(pl);
                             }
                         }
-                    });
+                    }
                 }
             }
         }

--- a/Services/Concrete/Analyzer/ValveAnalyzer.cs
+++ b/Services/Concrete/Analyzer/ValveAnalyzer.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using Core.Models;
 using Core.Models.Events;
 using DemoInfo;
@@ -168,11 +167,8 @@ namespace Services.Concrete.Analyzer
                             Name = player.Name,
                             Side = player.Team.ToSide(),
                         };
-                        Application.Current.Dispatcher.Invoke(delegate
-                        {
-                            Demo.Players.Add(pl);
-                            pl.TeamName = pl.Side == Side.CounterTerrorist ? Demo.TeamCT.Name : Demo.TeamT.Name;
-                        });
+                        Demo.Players.Add(pl);
+                        pl.TeamName = pl.Side == Side.CounterTerrorist ? Demo.TeamCT.Name : Demo.TeamT.Name;
                     }
                 }
             }
@@ -192,7 +188,7 @@ namespace Services.Concrete.Analyzer
             if (IsLastRoundHalf)
             {
                 SwapTeams();
-                Application.Current.Dispatcher.Invoke(() => Demo.Rounds.Add(CurrentRound));
+                Demo.Rounds.Add(CurrentRound);
             }
 
             if (IsOvertime && IsLastRoundHalf)
@@ -215,7 +211,7 @@ namespace Services.Concrete.Analyzer
                 _isRoundFinal = false;
                 if (IsOvertime)
                 {
-                    Application.Current.Dispatcher.Invoke(() => Demo.Overtimes.Add(CurrentOvertime));
+                    Demo.Overtimes.Add(CurrentOvertime);
                     IsHalfMatch = !IsHalfMatch;
                 }
                 else
@@ -431,11 +427,11 @@ namespace Services.Concrete.Analyzer
             {
                 if (Demo.TeamCT.Players.Count > Demo.TeamT.Players.Count)
                 {
-                    Application.Current.Dispatcher.Invoke(() => Demo.TeamT.Players.Add(player));
+                    Demo.TeamT.Players.Add(player);
                 }
                 else
                 {
-                    Application.Current.Dispatcher.Invoke(() => Demo.TeamCT.Players.Add(player));
+                    Demo.TeamCT.Players.Add(player);
                 }
             }
         }
@@ -446,7 +442,7 @@ namespace Services.Concrete.Analyzer
 
         private void StartMatch()
         {
-            Application.Current.Dispatcher.Invoke(() => Demo.Rounds.Clear());
+            Demo.Rounds.Clear();
             IsMatchStarted = true;
 
             if (!string.IsNullOrWhiteSpace(Parser.CTClanName))
@@ -476,21 +472,18 @@ namespace Services.Concrete.Analyzer
                     };
                     if (!Demo.Players.Contains(pl))
                     {
-                        Application.Current.Dispatcher.Invoke(delegate
+                        Demo.Players.Add(pl);
+                        if (pl.Side == Side.CounterTerrorist && !Demo.TeamCT.Players.Contains(pl))
                         {
-                            Demo.Players.Add(pl);
-                            if (pl.Side == Side.CounterTerrorist && !Demo.TeamCT.Players.Contains(pl))
-                            {
-                                Demo.TeamCT.Players.Add(pl);
-                                pl.TeamName = Demo.TeamCT.Name;
-                            }
+                            Demo.TeamCT.Players.Add(pl);
+                            pl.TeamName = Demo.TeamCT.Name;
+                        }
 
-                            if (pl.Side == Side.Terrorist && !Demo.TeamT.Players.Contains(pl))
-                            {
-                                Demo.TeamT.Players.Add(pl);
-                                pl.TeamName = Demo.TeamT.Name;
-                            }
-                        });
+                        if (pl.Side == Side.Terrorist && !Demo.TeamT.Players.Contains(pl))
+                        {
+                            Demo.TeamT.Players.Add(pl);
+                            pl.TeamName = Demo.TeamT.Name;
+                        }
                     }
                 }
             }

--- a/Services/Design/DemosDesignService.cs
+++ b/Services/Design/DemosDesignService.cs
@@ -97,7 +97,6 @@ namespace Services.Design
                     HeGrenadeThrownCount = random.Next(20),
                     BombExplodedCount = random.Next(5),
                     AvatarUrl = string.Empty,
-                    KillDeathRatio = (decimal)random.NextDouble(),
                     MatchCount = random.Next(100),
                     RoundPlayedCount = random.Next(100),
                 };


### PR DESCRIPTION
- Will allow to analyze demos from programs without windows
- The UI now have partial live update during analyzing but it leads to faster analyzes
- Adding an headless mode without this refactor is possible but leads to hacky workaround to access the console output, it's better to create a new project for the CLI
- The core project still relies on `ObservableObject` from the `MvvmLight` lib. The modern way is to use the one from the "Windows Community Toolkit" but it's Win 10+ only
- The field "most_damaging_weapon" has been added in the JSON export