### PR TITLE
fix(cli): add --output flag to csdm video --help

### DIFF
--- a/src/cli/commands/video-command.ts
+++ b/src/cli/commands/video-command.ts
@@ -191,6 +191,7 @@ export class VideoCommand extends Command {
     console.log(`  --${this.cfgFlag} <string>`);
     console.log(`  --${this.focusPlayerFlag} <steamId>`);
     console.log(`  --${this.configFileFlag} <path> (path to config JSON file)`);
+    console.log(`  --${this.outputFlag} <path> (output folder for generated videos)`);
     console.log(`  --verbose`);
     console.log('');
     console.log(`Player mode options (when --mode ${Mode.Player}):`);


### PR DESCRIPTION
**What this PR does**

Adds the missing `--output` / `-o` flag documentation to `csdm video --help`.

**The problem**

The flag was defined and parsed:
```typescript
private readonly outputFlag = 'output';
[this.outputFlag]: { type: 'string', short: 'o' },
```

But never printed in `printHelp()`, making it undiscoverable for users.

**The fix**

One line addition:
```typescript
console.log(`  --${this.outputFlag} <path> (output folder for generated videos)`);
```

**Related issue**

Fixes #1332