### PR TITLE
fix: possible crash during demo playback / video recording

### DIFF
--- a/cs2-server-plugin/cs2-server-plugin/cdll_interfaces.h
+++ b/cs2-server-plugin/cs2-server-plugin/cdll_interfaces.h
@@ -13,11 +13,11 @@ public:
     virtual void _Unknown_000(void) = 0;
     virtual void _Unknown_001(void) = 0;
 #if defined _WIN32
-    virtual int GetDemoStartTick(void) = 0; //:002
-    virtual int _GetDemoTick(void) = 0; // see :004
+    virtual int _Unknown_002(void) = 0;
+    virtual int _GetDemoTick(void) = 0; // :003 see :004
 #else
     virtual int _Unknown_002(void) = 0;
-    virtual int GetDemoStartTick(void) = 0; //:003
+    virtual int _Unknown_003(void) = 0;
 #endif
     virtual int GetDemoTick(void) = 0; //:004 points to the same function as :003 on Windows
     virtual int _Unknown_005(void) = 0;
@@ -26,9 +26,8 @@ public:
     virtual int _Unknown_008(void) = 0;
     virtual int _Unknown_009(void) = 0;
     virtual int _Unknown_010(void) = 0;
-    virtual int _Unknown_011(void) = 0;
-    virtual bool IsPlayingDemo(void) = 0; //:012
-    virtual bool IsDemoPaused(void) = 0; //:013
+    virtual bool IsPlayingDemo(void) = 0; //:011
+    virtual bool IsDemoPaused(void) = 0; //:012
 };
 
 
@@ -103,4 +102,66 @@ public:
     virtual void _Unknown_065(void) = 0;
     virtual void _Unknown_066(void) = 0;
     virtual IDemoPlayer* GetDemoPlayer(void) = 0; //:067
+};
+
+enum class ClientFrameStage_t : int
+{
+    // (haven't run any frames yet)
+    FRAME_UNDEFINED = -1,
+    FRAME_START = 0,
+    // A network packet is being recieved
+    FRAME_NET_UPDATE_START,
+    // Data has been received and we're going to start calling PostDataUpdate
+    FRAME_NET_UPDATE_POSTDATAUPDATE_START,
+    // Data has been received and we've called PostDataUpdate on all data recipients
+    FRAME_NET_UPDATE_POSTDATAUPDATE_END,
+    // We've received all packets, we can now do interpolation, prediction, etc..
+    FRAME_NET_UPDATE_END,
+    // We're about to start rendering the scene
+    FRAME_RENDER_START,
+    // We've finished rendering the scene.
+    FRAME_RENDER_END
+};
+
+
+abstract_class ISource2Client
+{
+public:
+    virtual void _Unknown_000(void) = 0;
+    virtual void _Unknown_001(void) = 0;
+    virtual void _Unknown_002(void) = 0;
+    virtual void _Unknown_003(void) = 0;
+    virtual void _Unknown_004(void) = 0;
+    virtual void _Unknown_005(void) = 0;
+    virtual void _Unknown_006(void) = 0;
+    virtual void _Unknown_007(void) = 0;
+    virtual void _Unknown_008(void) = 0;
+    virtual void _Unknown_009(void) = 0;
+    virtual void _Unknown_010(void) = 0;
+    virtual void _Unknown_011(void) = 0;
+    virtual void _Unknown_012(void) = 0;
+    virtual void _Unknown_013(void) = 0;
+    virtual void _Unknown_014(void) = 0;
+    virtual void _Unknown_015(void) = 0;
+    virtual void _Unknown_016(void) = 0;
+    virtual void _Unknown_017(void) = 0;
+    virtual void _Unknown_018(void) = 0;
+    virtual void _Unknown_019(void) = 0;
+    virtual void _Unknown_020(void) = 0;
+    virtual void _Unknown_021(void) = 0;
+    virtual void _Unknown_022(void) = 0;
+    virtual void _Unknown_023(void) = 0;
+    virtual void _Unknown_024(void) = 0;
+    virtual void _Unknown_025(void) = 0;
+    virtual void _Unknown_026(void) = 0;
+    virtual void _Unknown_027(void) = 0;
+    virtual void _Unknown_028(void) = 0;
+    virtual void _Unknown_029(void) = 0;
+    virtual void _Unknown_030(void) = 0;
+    virtual void _Unknown_031(void) = 0;
+    virtual void _Unknown_032(void) = 0;
+    virtual void _Unknown_033(void) = 0;
+    virtual void _Unknown_034(void) = 0;
+    virtual void _Unknown_035(void) = 0;
+    virtual void FrameStageNotify(ClientFrameStage_t curStage);
 };

--- a/cs2-server-plugin/cs2-server-plugin/main.cpp
+++ b/cs2-server-plugin/cs2-server-plugin/main.cpp
@@ -1,5 +1,7 @@
+#include <atomic>
 #include <thread>
 #include <fstream>
+#include <mutex>
 #include <queue>
 #include <sstream>
 #include <nlohmann/json.hpp>
@@ -26,9 +28,9 @@ using std::string;
 
 void* GetLibAddress(void* lib, const char* name) {
 #if defined _WIN32
-	return GetProcAddress((HMODULE)lib, name);
+    return GetProcAddress((HMODULE)lib, name);
 #else
-	return dlsym(lib, name);
+    return dlsym(lib, name);
 #endif
 }
 
@@ -38,9 +40,9 @@ char* GetLastErrorString() {
     static char s[_MAX_U64TOSTR_BASE2_COUNT];
     sprintf(s, "%lu", error);
 
-	return s;
+    return s;
 #else
-	return dlerror();
+    return dlerror();
 #endif
 }
 
@@ -48,7 +50,7 @@ void* LoadLib(const char* path) {
 #ifdef _WIN32
     return LoadLibrary(path);
 #else
-	return dlopen(path, RTLD_NOW);
+    return dlopen(path, RTLD_NOW);
 #endif
 }
 
@@ -63,25 +65,34 @@ struct Sequence {
 
 typedef bool (*AppSystemConnectFn)(IAppSystem* appSystem, CreateInterfaceFn factory);
 typedef void (*AppSystemShutdownFn)();
+typedef void (*FrameStageNotifyFn)(void* thisptr, ClientFrameStage_t curStage);
+typedef void (*ClientFullyConnectFn)(void* thisptr, int playerSlot);
 
 CreateInterfaceFn factory = NULL;
 AppSystemConnectFn serverConfigConnect = NULL;
+ClientFullyConnectFn originalClientFullyConnect = NULL;
 AppSystemShutdownFn serverConfigShutdown = NULL;
 CreateInterfaceFn serverCreateInterface = NULL;
 ISource2EngineToClient* engineToClient = NULL;
+ISource2Client* client = NULL;
+FrameStageNotifyFn originalFrameStageNotify = NULL;
 ICvar* g_pCVar = NULL;
 std::thread* wsConnectionThread = NULL;
-std::thread* demoPlaybackThread = NULL;
 WebSocket::pointer ws;
 string gameInfoPath;
 string gameInfoBackupPath;
 const char* demoPath = NULL;
 bool isPlayingDemo = false;
-int currentTick = -1;
-bool isQuitting = false;
-bool initialized = false;
-int lastPauseTick = -1;
+std::atomic<int> currentTick{-1};
+std::atomic<bool> isQuitting{false};
+bool shouldDeleteLogFile = true;
+std::mutex sequencesMutex;
 std::queue<Sequence> sequences;
+std::mutex pendingCommandsMutex;
+std::queue<std::string> pendingCommands;
+std::atomic<bool> captureInProgress{false};
+std::chrono::steady_clock::time_point captureStartTime;
+std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
 
 void LogToFile(const char* pMsg) {
     FILE* pFile = fopen("csdm.log", "a");
@@ -99,14 +110,14 @@ void DeleteLogFile()
     remove("csdm.log");
 }
 
-void Log(const char *msg, ...)
+void Log(const char* msg, ...)
 {
-	va_list args;
-	va_start(args, msg);
-	char buf[1024] = {};
-	vsnprintf(buf, sizeof(buf), msg, args);
-	ConColorMsg(Color(227, 0, 255, 255), "CSDM: %s\n", buf);
-	va_end(args);
+    va_list args;
+    va_start(args, msg);
+    char buf[1024] = {};
+    vsnprintf(buf, sizeof(buf), msg, args);
+    ConColorMsg(Color(227, 0, 255, 255), "CSDM: %s\n", buf);
+    va_end(args);
     LogToFile(buf);
 }
 
@@ -119,12 +130,12 @@ void PluginError(const char* msg, ...)
     va_end(args);
 
     // Since the "Armory" update, calling Plat_FatalErrorFunc crashes the game on Windows.
-    #ifdef _WIN32
-        Plat_MessageBox("Error", buf);
-        Plat_ExitProcess(1);
-    #else
-        Plat_FatalErrorFunc("%s", buf);
-    #endif
+#ifdef _WIN32
+    Plat_MessageBox("Error", buf);
+    Plat_ExitProcess(1);
+#else
+    Plat_FatalErrorFunc("%s", buf);
+#endif
 }
 
 inline bool FileExists(const std::string& name) {
@@ -153,6 +164,39 @@ static void UnhideCommandsAndCvars()
             ref.RemoveFlags(flagsToRemove);
         }
     }
+}
+
+void PatchVTableEntry(void** vtable, int index, void* newFunc) {
+    size_t protectSize = sizeof(void*) * (index + 1);
+#ifdef _WIN32
+    DWORD oldProtect = 0;
+    if (!VirtualProtect(vtable, protectSize, PAGE_EXECUTE_READWRITE, &oldProtect))
+    {
+        PluginError("VirtualProtect PAGE_EXECUTE_READWRITE failed: %d", GetLastError());
+    }
+    vtable[index] = newFunc;
+    DWORD ignore = 0;
+    if (!VirtualProtect(vtable, protectSize, oldProtect, &ignore))
+    {
+        PluginError("VirtualProtect restore failed: %d", GetLastError());
+    }
+#else
+    void* pageStart = (void*)((uintptr_t)vtable & ~(PAGESIZE - 1));
+    if (mprotect(pageStart, PAGESIZE, PROT_READ | PROT_WRITE | PROT_EXEC) != 0)
+    {
+        PluginError("mprotect failed: %s", strerror(errno));
+    }
+    vtable[index] = newFunc;
+    if (mprotect(pageStart, PAGESIZE, PROT_READ | PROT_EXEC) != 0)
+    {
+        PluginError("mprotect restore failed: %s", strerror(errno));
+    }
+#endif
+}
+
+void QueueEngineCommand(const std::string& cmd) {
+    std::lock_guard<std::mutex> lock(pendingCommandsMutex);
+    pendingCommands.push(cmd);
 }
 
 ISource2EngineToClient* GetEngine()
@@ -211,11 +255,12 @@ void RestoreGameinfoFile() {
 }
 
 void LoadSequencesFile(string demoPath) {
+    std::lock_guard<std::mutex> lock(sequencesMutex);
     sequences = {};
 
     string demoJsonPath = demoPath + ".json";
     if (FileExists(demoJsonPath)) {
-        Log("Loading JSON file %s",  demoJsonPath.c_str());
+        Log("Loading JSON file %s", demoJsonPath.c_str());
         std::ifstream jsonFile(demoJsonPath);
         json jsonSequences = json::parse(jsonFile);
 
@@ -250,87 +295,106 @@ void LoadSequencesFile(string demoPath) {
     }
 }
 
-void PlaybackLoop() {
-    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+void NewFrameStageNotify(void* thisptr, ClientFrameStage_t stage)
+{    
+    if (stage != ClientFrameStage_t::FRAME_START) {
+        originalFrameStageNotify(thisptr, stage);
+        return;
+    }
 
-    while (true) {
-        if (isQuitting) {
-            Log("[%d] Exiting playback loop", currentTick);
-            break;
+    if (isQuitting) {
+        originalFrameStageNotify(thisptr, stage);
+        return;
+    }
+
+    auto engine = GetEngine();
+    if (engine == NULL) {
+        Log("Engine interface not found");
+        originalFrameStageNotify(thisptr, stage);
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(pendingCommandsMutex);
+        while (!pendingCommands.empty()) {
+            std::string cmd = pendingCommands.front();
+            pendingCommands.pop();
+            Log("Executing queued command: %s", cmd.c_str());
+            engine->ExecuteClientCmd(0, cmd.c_str(), true);
+            Log("Executed queued command: %s", cmd.c_str());
         }
+    }
 
-        auto engine = GetEngine();
-        if (engine == NULL) {
-            Log("[%d] Engine interface not found", currentTick);
-            continue;
+    // Workaround to start demo playback when Steam is in offline mode, the +playdemo launch option doesn't work in this case.
+    if (demoPath != NULL) {
+        auto now = std::chrono::steady_clock::now();
+        auto secondsSinceStart = std::chrono::duration_cast<std::chrono::seconds>(now - startTime).count();
+        if (!engine->IsPlayingDemo() && secondsSinceStart >= 8) {
+            string cmd = "playdemo \"" + string(demoPath) + "\"";
+            demoPath = NULL;
+            Log("Force playing demo: %s", cmd.c_str());
+            engine->ExecuteClientCmd(0, cmd.c_str(), true);
+            Log("Forced playing demo: %s", cmd.c_str());
         }
+    }
 
-        if (!initialized) {
-            Log("[%d] Initializing", currentTick);
-            // Required to make the spec_lock_to_accountid command working since the 25/04/2024 update - it looks like the command has been hidden.
-            // Also required to use the startmovie command.
-            UnhideCommandsAndCvars();
-
-            // Since the 23/05/2024 CS2 update, the demo playback UI is displayed by default.
-			// We have to set the demo_ui_mode convar to 0 before starting the playback prevent the UI from being displayed.
-            engine->ExecuteClientCmd(0, "demo_ui_mode 0", true);
-            engine->ExecuteClientCmd(0, "sv_cheats 1", true); // required to unlock commands such as getposcopy
-
-            // Workaround to start demo playback when Steam is in offline mode, the +playdemo launch option doesn't work in this case.
-            if (demoPath != NULL) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(6000));
-                if (!engine->IsPlayingDemo()) {
-                    string cmd = "playdemo \"" + string(demoPath) + "\"";
-                    Log("Force playing demo: %s", cmd.c_str());
-                    engine->ExecuteClientCmd(0, cmd.c_str(), true);
-                }
-            }
-
-            initialized = true;
-            Log("[%d] Initialized", currentTick);
+    // Handle capture-player-view delayed endmovie
+    if (captureInProgress) {
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - captureStartTime).count();
+        if (elapsed >= 1000) {
+            Log("Ending movie capture");
+            engine->ExecuteClientCmd(0, "endmovie", true);
+            captureInProgress = false;
+            json responseMsg;
+            responseMsg["name"] = "capture-player-view-result";
+            SendMsg(responseMsg);
         }
+    }
 
-        bool newIsPlayingDemo = engine->IsPlayingDemo();
+    auto demo = engine->GetDemoPlayer();
+    if (demo == NULL) {
+        Log("Demo player interface not found");
+        originalFrameStageNotify(thisptr, stage);
+        return;
+    }
+
+    int newTick = demo->GetDemoTick();
+    bool newIsPlayingDemo = engine->IsPlayingDemo();
+    {
         if (newIsPlayingDemo && !isPlayingDemo) {
-            Log("[%d] Demo playback started, sequences %d", currentTick, sequences.size());
-            currentTick = -1;
+            std::lock_guard<std::mutex> lock(sequencesMutex);
+            Log("[%d] Demo playback started, sequences %d", newTick, sequences.size());
         }
         else if (!newIsPlayingDemo && isPlayingDemo) {
-            Log("[%d] Demo playback stopped, sequences %d", currentTick, sequences.size());
-            currentTick = -1;
+            std::lock_guard<std::mutex> lock(sequencesMutex);
+            Log("[%d] Demo playback stopped, sequences %d", newTick, sequences.size());
         }
+    }
 
-        isPlayingDemo = newIsPlayingDemo;
-        if (!isPlayingDemo) {
-            continue;
-        }
+    isPlayingDemo = newIsPlayingDemo;
+    if (!isPlayingDemo) {
+        originalFrameStageNotify(thisptr, stage);
+        return;
+    }
 
-        auto demo = engine->GetDemoPlayer();
-        if (demo == NULL) {
-            Log("[%d] Demo player interface not found", currentTick);
-            continue;
-        }
-
-        int newTick = demo->GetDemoTick();
+    {
+        std::lock_guard<std::mutex> lock(sequencesMutex);
         if (newTick != currentTick && !sequences.empty()) {
-            // Log("Tick: %d", newTick);
+            // Log("Tick: %d -> %d", currentTick.load(), newTick);
 
             Sequence& currentSequence = sequences.front();
             for (auto& action : currentSequence.actions) {
-                if (action.tick != newTick) {
+                // Tick: 4 -> 5
+                // Tick: 5 -> 6
+                // Tick: 6 -> 8
+                // Tick: 8 -> 9
+                // Some ticks may be skipped, we execute actions for all ticks between the current tick and the new tick.
+                if (action.tick > newTick || action.tick <= currentTick) {
                     continue;
                 }
 
                 if (action.cmd == "pause_playback") {
-                    // Since an October 2025 CS2 update, the tick after executing demo_pause and then demo_resume may be "in the past".
-                    // For example pausing the demo at tick 1000 and resuming it may result in the current tick being 998.
-                    // To avoid pausing the demo indefinitely, we check if we already paused at this tick.
-                    if (lastPauseTick != -1 && lastPauseTick == newTick) {
-                        lastPauseTick = -1;
-                        continue;
-                    }
-
-                    lastPauseTick = newTick;
                     Log("[%d] Pausing demo playback", newTick);
                     engine->ExecuteClientCmd(0, "demo_pause", true);
                     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
@@ -342,7 +406,6 @@ void PlaybackLoop() {
                     sequences.pop();
                     engine->ExecuteClientCmd(0, "demo_gototick 0", true);
                     currentTick = -1;
-                    lastPauseTick = -1;
                     break;
                 }
                 else {
@@ -352,14 +415,16 @@ void PlaybackLoop() {
                 }
             }
         }
-
-        currentTick = newTick;
     }
+
+    currentTick = newTick;
+
+    originalFrameStageNotify(thisptr, stage);
 }
 
 void HandleWebSocketMessage(const std::string& message)
 {
-    Log("[%d] Message received: %s", currentTick, message.c_str());
+    Log("[%d] Message received: %s", currentTick.load(), message.c_str());
 
     json msg = json::parse(message.c_str());
     if (!msg.contains("name")) {
@@ -374,32 +439,17 @@ void HandleWebSocketMessage(const std::string& message)
         LoadSequencesFile(demoPath);
 
         string cmd = "playdemo \"" + demoPath + "\"";
-        Log("Starting demo: %s", cmd.c_str());
-        auto engine = GetEngine();
-        if (engine == NULL) {
-            Log("Engine interface not found");
-            return;
-        }
-        engine->ExecuteClientCmd(0, cmd.c_str(), true);
-        Log("Demo started: %s", cmd.c_str());
+        QueueEngineCommand(cmd);
     }
     else if (msg["name"] == "capture-player-view") {
         Log("Capturing player view");
-        auto engine = GetEngine();
-        if (engine == NULL) {
-            Log("Engine interface not found");
-            return;
-        }
-        engine->ExecuteClientCmd(0, "getposcopy", true);
+        QueueEngineCommand("getposcopy");
         // The "screenshot" command works only on Windows when the -tools launch option is set.
         // As a workaround, we use the startmovie command to take a screenshot.
-        engine->ExecuteClientCmd(0, "hideconsole", true);
-        engine->ExecuteClientCmd(0, "startmovie csdmcamera jpg", true);
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        engine->ExecuteClientCmd(0, "endmovie", true);
-        json responseMsg;
-        responseMsg["name"] = "capture-player-view-result";
-        SendMsg(responseMsg);
+        QueueEngineCommand("hideconsole");
+        QueueEngineCommand("startmovie csdmcamera jpg");
+        captureStartTime = std::chrono::steady_clock::now();
+        captureInProgress = true;
     }
 }
 
@@ -411,7 +461,7 @@ void ConnectToWebsocketServer() {
         Log("Failed to connect to WebSocket server.");
         return;
     }
-    
+
     Log("Connected to WebSocket server.");
     while (ws->getReadyState() != WebSocket::CLOSED && !isQuitting) {
         ws->poll();
@@ -448,12 +498,14 @@ bool Connect(IAppSystem* appSystem, CreateInterfaceFn factoryFn)
     bool result = serverConfigConnect(appSystem, factory);
 
     g_pCVar = (ICvar*)factory("VEngineCvar007", NULL);
-    #ifdef CON_COMMAND_ENABLED
-        ConVar_Register();
-    #endif
+    // Required to make the spec_lock_to_accountid command working since the 25/04/2024 update - it looks like the command has been hidden.
+    // Also required to use the startmovie command.
+    UnhideCommandsAndCvars();
+#ifdef CON_COMMAND_ENABLED
+    ConVar_Register();
+#endif
 
     wsConnectionThread = new std::thread(ConnectToWebsocketServerLoop);
-    demoPlaybackThread = new std::thread(PlaybackLoop);
 
     RestoreGameinfoFile();
 
@@ -469,9 +521,9 @@ void Shutdown()
         serverConfigShutdown();
     }
 
-    #ifdef CON_COMMAND_ENABLED
-        ConVar_Unregister();
-    #endif
+#ifdef CON_COMMAND_ENABLED
+    ConVar_Unregister();
+#endif
 
     if (ws != NULL) {
         ws->close();
@@ -481,38 +533,65 @@ void Shutdown()
         wsConnectionThread->join();
         wsConnectionThread = NULL;
     }
-
-    if (demoPlaybackThread != NULL) {
-        demoPlaybackThread->join();
-        demoPlaybackThread = NULL;
-    }
 }
 
 void AssertInsecureParameterIsPresent()
 {
     bool found = false;
-	// Since the "Armory" update, calling CommandLine()->HasParm("-insecure") crashes the game when the parameter is not present.
+    // Since the "Armory" update, calling CommandLine()->HasParm("-insecure") crashes the game when the parameter is not present.
     auto parameters = CommandLine()->GetParms();
-	for (int i = 0; i < CommandLine()->ParmCount(); i++)
-	{
-		if (strcmp(parameters[i], "-insecure") == 0)
-		{
-			found = true;
-			break;
-		}
-	}
+    for (int i = 0; i < CommandLine()->ParmCount(); i++)
+    {
+        if (strcmp(parameters[i], "-insecure") == 0)
+        {
+            found = true;
+            break;
+        }
+    }
 
-	if (!found)
-	{
-		PluginError("CS:DM plugin loaded without the -insecure launch option.\n\nAborting.");
-	}
+    if (!found)
+    {
+        PluginError("CS:DM plugin loaded without the -insecure launch option.\n\nAborting.");
+    }
+}
+
+void NewClientFullyConnect(void* thisptr, int playerSlot)
+{
+    Log("ClientFullyConnect: playerSlot=%d", playerSlot);
+    if (client != NULL) {
+        originalClientFullyConnect(thisptr, playerSlot);
+        return;
+    }
+
+    // Hook FrameStageNotify to call engine commands from the engine thread since it's not thread safe to call engine
+    // commands from another thread.
+    client = (ISource2Client*)factory("Source2Client002", NULL);
+    if (client != NULL) {
+        Log("Hooking FrameStageNotify");
+        auto vtable = *(void***)client;
+        originalFrameStageNotify = (FrameStageNotifyFn)vtable[36];
+        PatchVTableEntry(vtable, 36, (void*)&NewFrameStageNotify);
+        Log("Hooked FrameStageNotify");
+    }
+    
+    // Since the 23/05/2024 CS2 update, the demo playback UI is displayed by default.
+    // We have to set the demo_ui_mode convar to 0 before starting the playback prevent the UI from being displayed.
+    QueueEngineCommand("demo_ui_mode 0");
+    QueueEngineCommand("sv_cheats 1"); // required to unlock commands such as getposcopy
+
+    originalClientFullyConnect(thisptr, playerSlot);
 }
 
 EXPORT void* CreateInterface(const char* pName, int* pReturnCode)
 {
+    if (shouldDeleteLogFile) {
+        DeleteLogFile();
+        shouldDeleteLogFile = false;
+    }
+    
+    Log("CreateInterface called with %s", pName);
     if (serverCreateInterface == NULL)
     {
-        DeleteLogFile();
         AssertInsecureParameterIsPresent();
 
         const char* gameDirectory = Plat_GetGameDirectory();
@@ -534,42 +613,17 @@ EXPORT void* CreateInterface(const char* pName, int* pReturnCode)
     }
 
     void* original = serverCreateInterface(pName, pReturnCode);
+    auto vtable = *(void***)original;
     if (strcmp(pName, "Source2ServerConfig001") == 0)
     {
-        auto vtable = *(void***)original;
         serverConfigConnect = (AppSystemConnectFn)vtable[0];
         serverConfigShutdown = (AppSystemShutdownFn)vtable[4];
-
-#if defined _WIN32
-        DWORD oldProtect = 0;
-        if (!VirtualProtect(vtable, sizeof(void*) * 5, PAGE_EXECUTE_READWRITE, &oldProtect))
-        {
-            PluginError("VirtualProtect PAGE_EXECUTE_READWRITE failed: %d", GetLastError());
-        }
-
-        vtable[0] = &Connect;
-        vtable[4] = &Shutdown;
-
-        DWORD ignore = 0;
-        if (!VirtualProtect(vtable, sizeof(void*) * 5, oldProtect, &ignore))
-        {
-            PluginError("VirtualProtect restore failed: %d", GetLastError());
-        }
-#else
-        void* pageStart = (void*)((uintptr_t)vtable & ~(PAGESIZE - 1));
-        if (mprotect(pageStart, PAGESIZE, PROT_READ | PROT_WRITE | PROT_EXEC) != 0)
-        {
-            PluginError("mprotect failed: %s", strerror(errno));
-        }
-
-        vtable[0] = reinterpret_cast<void*>(&Connect);
-        vtable[4] = reinterpret_cast<void*>(&Shutdown);
-
-        if (mprotect(pageStart, PAGESIZE, PROT_READ | PROT_EXEC) != 0)
-        {
-            PluginError("mprotect restore failed: %s", strerror(errno));
-        }
-#endif
+        PatchVTableEntry(vtable, 0, (void*)&Connect);
+        PatchVTableEntry(vtable, 4, (void*)&Shutdown);
+    } else if (strcmp(pName, "Source2GameClients001") == 0)
+    {
+        originalClientFullyConnect = (ClientFullyConnectFn)vtable[15];
+        PatchVTableEntry(vtable, 15, (void*)&NewClientFullyConnect);
     }
 
     if (demoPath == NULL) {
@@ -590,7 +644,7 @@ EXPORT void* CreateInterface(const char* pName, int* pReturnCode)
 #ifdef CON_COMMAND_ENABLED
 CON_COMMAND(csdm_info, "Prints CS:DM plugin info")
 {
-    Log("Tick: %d", currentTick);
+    Log("Tick: %d", currentTick.load());
     Log("Is playing demo: %d", isPlayingDemo);
 
     if (ws != NULL) {
@@ -600,6 +654,9 @@ CON_COMMAND(csdm_info, "Prints CS:DM plugin info")
         Log("WebSocket not connected");
     }
 
-    Log("Sequence count: %d", sequences.size());
+    {
+        std::lock_guard<std::mutex> lock(sequencesMutex);
+        Log("Sequence count: %d", sequences.size());
+    }
 }
 #endif


### PR DESCRIPTION
ref #1302

- Call engine functions from the game's main thread by hooking `FrameStageNotify` and passing commands to execute through a queue.
- Add mutex/atomic when needed to be thread-safe.
- Fix offsets in IDemoPlayer (were not used but still).
- When using `FrameStageNotify` as a playback loop, ticks may be skipped, the changes consider it.
- The workaround based on the last pause tick to fix #1246 has been removed as the issue is not reproducible with the changes.
- The log file was deleted several times leading to missing logs, it's fixed.

Thank you @dtugend for your help!