### PR TITLE
fix(cli): set tickrate for CS2 demos so spec_player isn't dropped

### DIFF
--- a/src/node/demo/get-demo-from-file-path.ts
+++ b/src/node/demo/get-demo-from-file-path.ts
@@ -183,6 +183,7 @@ async function buildDemoFromFilePath(filePath: string): Promise<Demo> {
     }
   } else {
     buildNumber = header.buildNumber;
+    tickrate = 64;
     // The build number of CS2 when it was publicly available is 9832, everything below is coming from the limited test.
     if (buildNumber < 9832) {
       game = Game.CS2LT;


### PR DESCRIPTION
Fixes #1388 — full diagnosis there.

`buildDemoFromFilePath` never sets `tickrate` for CS2 demos, so `demo.tickrate` is `0` for every CS2 demo. `video-command.ts` then passes that `0` into `generateVideo` for every CLI mode, collapsing the `demo_gototick` → `spec_player` gap in `create-cs2-video-json-file.ts` from ~1s to a single tick. Per the existing comment in that file, CS2 silently drops `spec_player` when issued that close to a seek, so the CLI intermittently renders the default spectator instead of the requested `playerSteamId`. The UI is unaffected because it sources tickrate from `match.tickrate` (DB-backed, correctly 64).

CS2 is fixed-rate at 64 and `CDemoFileHeader` (PBDEMS2) doesn't expose tickrate, so a constant matches what the analyzer writes to the DB.

## Verification

We applied the same one-line patch on top of CSDM 3.19.0, built a patched `.deb`, and ran it across our render pipeline — the bug stopped recurring across all CLI modes (`--config-file`, `--mode player --event rounds`, `--focus-player`).

We have not been able to verify against current `main` (3.19.2) directly: our demo corpus is pinned to CS2 1.41.4.1 (build 22627914) because the 2026-04-23 CS2 update changed the `.dem` binary format and broke parsing on it. The surrounding code in `get-demo-from-file-path.ts` is byte-identical between 3.19.0 and 3.19.2, so the patch's behavior should carry over unchanged.