### PR TITLE
fix: mprotect the target slot's page in PatchVTableEntry

### DIFF
--- a/cs2-server-plugin/cs2-server-plugin/main.cpp
+++ b/cs2-server-plugin/cs2-server-plugin/main.cpp
@@ -181,7 +181,9 @@ void PatchVTableEntry(void** vtable, int index, void* newFunc) {
         PluginError("VirtualProtect restore failed: %d", GetLastError());
     }
 #else
-    void* pageStart = (void*)((uintptr_t)vtable & ~(PAGESIZE - 1));
+    // Use the page containing the slot we're writing, not the page containing table's base
+    void* slotAddr = (void*)&vtable[index];                                                                      
+    void* pageStart = (void*)((uintptr_t)slotAddr & ~(PAGESIZE - 1)); 
     if (mprotect(pageStart, PAGESIZE, PROT_READ | PROT_WRITE | PROT_EXEC) != 0)
     {
         PluginError("mprotect failed: %s", strerror(errno));

--- a/cs2-server-plugin/cs2-server-plugin/main.cpp
+++ b/cs2-server-plugin/cs2-server-plugin/main.cpp
@@ -182,8 +182,8 @@ void PatchVTableEntry(void** vtable, int index, void* newFunc) {
     }
 #else
     // Use the page containing the slot we're writing, not the page containing table's base
-    void* slotAddr = (void*)&vtable[index];                                                                      
-    void* pageStart = (void*)((uintptr_t)slotAddr & ~(PAGESIZE - 1)); 
+    void* slotAddr = (void*)&vtable[index];
+    void* pageStart = (void*)((uintptr_t)slotAddr & ~(PAGESIZE - 1));
     if (mprotect(pageStart, PAGESIZE, PROT_READ | PROT_WRITE | PROT_EXEC) != 0)
     {
         PluginError("mprotect failed: %s", strerror(errno));


### PR DESCRIPTION
One-line fix to compute pageStart from the slot address to avoid SIGSEGV on write. Should hopefully resolve #1393.

Hit while running CSDM v3.19.3 on Linux in a headless CS2 recorder (CS patch 1.41.5.9 May 06 2026, container running ubuntu:24.04). CS2 SIGSEGV'd shortly after plugin load and the backtrace pointed at PatchVTableEntry.  This should prevent mprotect missing a page if any vtable slot crosses the existing page boundary.

Working as expected after this change, haven't regression tested though. 